### PR TITLE
K8SPS-18: Configure semi-sync nodes through orchestrator

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -153,6 +153,8 @@ create_default_cnf() {
 	sed -i "/\[mysqld\]/a gtid-mode=ON" $CFG
 	sed -i "/\[mysqld\]/a enforce-gtid-consistency" $CFG
 	sed -i "/\[mysqld\]/a plugin-load-add=clone=mysql_clone.so" $CFG
+	sed -i "/\[mysqld\]/a plugin-load-add=rpl_semi_sync_master=semisync_master.so" $CFG
+	sed -i "/\[mysqld\]/a plugin-load-add=rpl_semi_sync_slave=semisync_slave.so" $CFG
 
 	if [[ -d ${TLS_DIR} ]]; then
 		sed -i "/\[mysqld\]/a ssl_ca=${TLS_DIR}/ca.crt" $CFG

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -7,6 +7,7 @@ spec:
   sslSecretName: cluster1-ssl
   mysql:
     size: 3
+    sizeSemiSync: 0
     imagePullPolicy: Always
     image: percona/percona-server:8.0.25
     volumeSpec:

--- a/pkg/cluster/replication.go
+++ b/pkg/cluster/replication.go
@@ -21,6 +21,10 @@ func (r *MySQLReconciler) reconcileReplication(log logr.Logger, cr *v2.PerconaSe
 		return errors.Wrap(err, "reconcile primary pod")
 	}
 
+	if err := r.reconcileSemiSync(log, cr); err != nil {
+		return errors.Wrap(err, "reconcile semi-sync")
+	}
+
 	return nil
 }
 
@@ -56,6 +60,41 @@ func (r *MySQLReconciler) reconcilePrimaryPod(log logr.Logger, cr *v2.PerconaSer
 		if err := r.Client.Update(context.TODO(), &pod); err != nil {
 			return errors.Wrap(err, "update primary pod")
 		}
+	}
+
+	return nil
+}
+
+func (r *MySQLReconciler) reconcileSemiSync(log logr.Logger, cr *v2.PerconaServerForMySQL) error {
+	o := orchestrator.New(cr)
+	orc := orclient.New(o.APIHost())
+	clusterHint := cr.ClusterHint()
+
+	primary, err := orc.ClusterPrimary(clusterHint)
+	if err != nil {
+		return errors.Wrap(err, "get primary from orchestrator")
+	}
+
+	operatorPass, err := k8s.UserPassword(r.Client, cr, v2.USERS_SECRET_KEY_OPERATOR)
+	if err != nil {
+		return errors.Wrap(err, "get operator password")
+	}
+
+	m, err := mysql.NewReplicator(v2.USERS_SECRET_KEY_OPERATOR, operatorPass, primary.Key.Hostname, int32(33062))
+	if err != nil {
+		return errors.Wrapf(err, "connect to %s", primary.Key.Hostname)
+	}
+
+	if err := m.SetSemiSyncSource(cr.Spec.MySQL.SizeSemiSync > 0); err != nil {
+		return errors.Wrapf(err, "set semi-sync on %s", primary.Key.Hostname)
+	}
+
+	if cr.Spec.MySQL.SizeSemiSync < 1 {
+		return nil
+	}
+
+	if err := m.SetSemiSyncSize(cr.Spec.MySQL.SizeSemiSync); err != nil {
+		return errors.Wrapf(err, "set semi-sync size on %s", primary.Key.Hostname)
 	}
 
 	return nil

--- a/pkg/cluster/replication.go
+++ b/pkg/cluster/replication.go
@@ -80,12 +80,13 @@ func (r *MySQLReconciler) reconcileSemiSync(log logr.Logger, cr *v2.PerconaServe
 		return errors.Wrap(err, "get operator password")
 	}
 
-	m, err := mysql.NewReplicator(v2.USERS_SECRET_KEY_OPERATOR, operatorPass, primary.Key.Hostname, int32(33062))
+	db, err := mysql.NewReplicator(v2.USERS_SECRET_KEY_OPERATOR, operatorPass, primary.Key.Hostname, int32(33062))
 	if err != nil {
 		return errors.Wrapf(err, "connect to %s", primary.Key.Hostname)
 	}
+	defer db.Close()
 
-	if err := m.SetSemiSyncSource(cr.Spec.MySQL.SizeSemiSync > 0); err != nil {
+	if err := db.SetSemiSyncSource(cr.Spec.MySQL.SizeSemiSync > 0); err != nil {
 		return errors.Wrapf(err, "set semi-sync on %s", primary.Key.Hostname)
 	}
 
@@ -93,7 +94,7 @@ func (r *MySQLReconciler) reconcileSemiSync(log logr.Logger, cr *v2.PerconaServe
 		return nil
 	}
 
-	if err := m.SetSemiSyncSize(cr.Spec.MySQL.SizeSemiSync); err != nil {
+	if err := db.SetSemiSyncSize(cr.Spec.MySQL.SizeSemiSync); err != nil {
 		return errors.Wrapf(err, "set semi-sync size on %s", primary.Key.Hostname)
 	}
 

--- a/pkg/database/mysql/replicator.go
+++ b/pkg/database/mysql/replicator.go
@@ -28,6 +28,8 @@ type Replicator interface {
 	CloneInProgress() (bool, error)
 	NeedsClone(donor string, port int32) (bool, error)
 	Clone(donor, user, pass string, port int32) error
+	SetSemiSyncSource(enabled bool) error
+	SetSemiSyncSize(size int32) error
 }
 
 type dbImpl sql.DB
@@ -165,4 +167,14 @@ func (d *dbImpl) Clone(donor, user, pass string, port int32) error {
 	}
 
 	return nil
+}
+
+func (d *dbImpl) SetSemiSyncSource(enabled bool) error {
+	_, err := (*sql.DB)(d).Exec("SET GLOBAL rpl_semi_sync_master_enabled=?", enabled)
+	return errors.Wrap(err, "set rpl_semi_sync_master_enabled")
+}
+
+func (d *dbImpl) SetSemiSyncSize(size int32) error {
+	_, err := (*sql.DB)(d).Exec("SET GLOBAL rpl_semi_sync_master_wait_for_slave_count=?", size)
+	return errors.Wrap(err, "set rpl_semi_sync_master_wait_for_slave_count")
 }

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v2 "github.com/percona/percona-server-mysql-operator/pkg/api/v2"
+)
+
+func UserPassword(cl client.Client, cr *v2.PerconaServerForMySQL, username string) (string, error) {
+	secret := &corev1.Secret{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: cr.Spec.SecretsName, Namespace: cr.Namespace}, secret)
+	if err != nil {
+		return "", errors.Wrapf(err, "get secret %s", cr.Spec.SecretsName)
+	}
+
+	pass, ok := secret.Data[username]
+	if !ok {
+		return "", errors.Errorf("no password for %s in secret %s", username, cr.Spec.SecretsName)
+	}
+
+	return string(pass), nil
+}


### PR DESCRIPTION
Orchestrator 3.2.6 has a new feature to enforce exact number of
semi-sync nodes. According to `rpl_semi_sync_master_wait_for_slave_count`
variable it enable/disable semi-sync replication on replica nodes.

If the user configures `sizeSemiSync` in `cr.yaml`, the operator enables semi-sync
replication on the primary (`set global rpl_semi_sync_master_enabled=1`)
and set `rpl_semi_sync_master_wait_for_slave_count` to the user defined
value. Afterwards, Orchestrator will detect a failure due to
`EnforceExactSemiSyncReplicas` config option of itself and will try to
configure replicas as semi-sync to reach to the desired state.

If the user sets `sizeSemiSync` to 0 or removes the field, the operator
disables the semi-sync on primary (`set global rpl_semi_sync_master_enabled=0`).
Orchestrator won't disable semi-sync on replicas in this scenario but
it's fine since the replication is async if only one side is semi-sync.

Note that, we're not using the new plugins that are introduced in
8.0.26. Orchestrator doesn't support this plugins yet and until they're
supported by it we need to stay on 8.0.25.