### PR TITLE
K8SPS-13 improve orchestrator discovery MySQL pods

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -126,7 +126,7 @@ _get_tmpdir() {
 
 	tmpdir_path=$(_get_cnf_config mysqld tmpdir "")
 	if [[ -z ${tmpdir_path} ]]; then
-		tmpdir_path=$(_get_cnf_config xtrabackup tmpdir "")
+		tmpdir_path=$(_get_cnf_config mysqld tmpdir "")
 	fi
 	if [[ -z ${tmpdir_path} ]]; then
 		tmpdir_path="$defaul_value"

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -234,12 +234,15 @@ func getTopology(peers sets.String) (string, []string, error) {
 		if err != nil {
 			return "", nil, errors.Wrap(err, "get report_host")
 		}
+		if replicaHost == "" {
+			continue
+		}
 
-		if replicaHost != "" && peers.Len() > 1 {
+		if peers.Len() > 1 {
 			replicas.Insert(replicaHost)
 		}
 
-		if status == mysql.ReplicationStatusActive && replicaHost != "" {
+		if status == mysql.ReplicationStatusActive {
 			primary = source
 		}
 	}

--- a/pkg/cluster/mysql.go
+++ b/pkg/cluster/mysql.go
@@ -42,6 +42,12 @@ func (r *MySQLReconciler) reconcileMySQL(log logr.Logger, cr *v2.PerconaServerFo
 	if err := r.createOrUpdate(log, primarySvc); err != nil {
 		return errors.Wrapf(err, "create or update %s/%s", svc.Kind, svc.Name)
 	}
-
+	unreadySvc := m.UnreadyService()
+	if err := k8s.SetControllerReference(cr, unreadySvc, r.Scheme); err != nil {
+		return errors.Wrapf(err, "set controller reference to %s/%s", svc.Kind, svc.Name)
+	}
+	if err := r.createOrUpdate(log, unreadySvc); err != nil {
+		return errors.Wrapf(err, "create or update %s/%s", svc.Kind, svc.Name)
+	}
 	return nil
 }

--- a/pkg/database/mysql/env.go
+++ b/pkg/database/mysql/env.go
@@ -11,6 +11,10 @@ func (m *MySQL) env() []corev1.EnvVar {
 			Value: m.ServiceName(),
 		},
 		{
+			Name:  "SERVICE_NAME_UNREADY",
+			Value: m.UnreadyServiceName(),
+		},
+		{
 			Name:  "CLUSTER_HASH",
 			Value: m.cluster.ClusterHash(),
 		},

--- a/pkg/database/mysql/replicator.go
+++ b/pkg/database/mysql/replicator.go
@@ -24,6 +24,7 @@ type Replicator interface {
 	ReplicationStatus() (ReplicationStatus, string, error)
 	EnableReadonly() error
 	IsReadonly() (bool, error)
+	ReportHost() (string, error)
 	Close() error
 	CloneInProgress() (bool, error)
 	NeedsClone(donor string, port int32) (bool, error)
@@ -106,6 +107,12 @@ func (d *dbImpl) IsReadonly() (bool, error) {
 	var readonly int
 	err := (*sql.DB)(d).QueryRow("select @@read_only").Scan(&readonly)
 	return readonly == 1, errors.Wrap(err, "select global read_only param")
+}
+
+func (d *dbImpl) ReportHost() (string, error) {
+	var reportHost string
+	err := (*sql.DB)(d).QueryRow("select @@report_host").Scan(&reportHost)
+	return reportHost, errors.Wrap(err, "select report_host param")
 }
 
 func (d *dbImpl) Close() error {

--- a/pkg/database/mysql/service.go
+++ b/pkg/database/mysql/service.go
@@ -15,6 +15,30 @@ func (m *MySQL) PrimaryServiceName() string {
 	return m.Name() + "-primary"
 }
 
+func (m *MySQL) UnreadyServiceName() string {
+	return m.Name() + "-unready"
+}
+
+func (m *MySQL) UnreadyService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.UnreadyServiceName(),
+			Namespace: m.Namespace(),
+			Labels:    m.MatchLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:                "None",
+			Ports:                    m.servicePorts(),
+			Selector:                 m.MatchLabels(),
+			PublishNotReadyAddresses: true,
+		},
+	}
+}
+
 func (m *MySQL) Service() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -27,10 +51,9 @@ func (m *MySQL) Service() *corev1.Service {
 			Labels:    m.MatchLabels(),
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP:                "None",
-			Ports:                    m.servicePorts(),
-			Selector:                 m.MatchLabels(),
-			PublishNotReadyAddresses: true,
+			ClusterIP: "None",
+			Ports:     m.servicePorts(),
+			Selector:  m.MatchLabels(),
 		},
 	}
 }


### PR DESCRIPTION
    * in mysql-monit container we need to use service for
      peer-list to get ready pods but by default
      <cluster-name>-mysql service has 'publishNotReadyAddresses=True'
      so, the additional service <cluster-name>-mysql-unready was
      created
    * addopt bootstrap to use <cluster-name>-mysql-unready service