### PR TITLE
K8SPS-28: Allow custom config for MySQL

### DIFF
--- a/api/v2/perconaserverformysql_types.go
+++ b/api/v2/perconaserverformysql_types.go
@@ -59,6 +59,8 @@ type MySQLSpec struct {
 	SidecarVolumes []corev1.Volume    `json:"sidecarVolumes,omitempty"`
 	SidecarPVCs    []SidecarPVC       `json:"sidecarPVCs,omitempty"`
 
+	Configuration string `json:"configuration,omitempty"`
+
 	PodSpec `json:",inline"`
 }
 

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -183,6 +183,12 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	rm -rfv "$TMPDIR"
 
 	create_default_cnf
+        if [ -f "/etc/mysql/config/my-config.cnf" ]; then
+            cat "/etc/mysql/config/my-config.cnf" >> $CFG
+        fi
+        if [ -f "/etc/mysql/config/my-secret.cnf" ]; then
+            cat "/etc/mysql/config/my-secret.cnf" >> $CFG
+        fi
 
 	if [ ! -d "$DATADIR/mysql" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD' '' 'root'

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -183,12 +183,12 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	rm -rfv "$TMPDIR"
 
 	create_default_cnf
-        if [ -f "/etc/mysql/config/my-config.cnf" ]; then
-            cat "/etc/mysql/config/my-config.cnf" >> $CFG
-        fi
-        if [ -f "/etc/mysql/config/my-secret.cnf" ]; then
-            cat "/etc/mysql/config/my-secret.cnf" >> $CFG
-        fi
+	if [ -f "/etc/mysql/config/my-config.cnf" ]; then
+		cat "/etc/mysql/config/my-config.cnf" >>$CFG
+	fi
+	if [ -f "/etc/mysql/config/my-secret.cnf" ]; then
+		cat "/etc/mysql/config/my-secret.cnf" >>$CFG
+	fi
 
 	if [ ! -d "$DATADIR/mysql" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD' '' 'root'

--- a/controllers/perconaserverformysql_controller.go
+++ b/controllers/perconaserverformysql_controller.go
@@ -18,13 +18,17 @@ package controllers
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sretry "k8s.io/client-go/util/retry"
@@ -192,12 +196,17 @@ func (r *PerconaServerForMySQLReconciler) reconcileDatabase(
 	ctx context.Context,
 	cr *apiv2.PerconaServerForMySQL,
 ) error {
+	configHash, err := r.reconcileMySQLConfiguration(ctx, cr)
+	if err != nil {
+		return errors.Wrap(err, "reconcile MySQL config")
+	}
+
 	initImage, err := k8s.InitImage(ctx, r.Client)
 	if err != nil {
 		return errors.Wrap(err, "get init image")
 	}
 
-	err = k8s.EnsureObjectWithHash(ctx, r.Client, cr, mysql.StatefulSet(cr, initImage), r.Scheme)
+	err = k8s.EnsureObjectWithHash(ctx, r.Client, cr, mysql.StatefulSet(cr, initImage, configHash), r.Scheme)
 	if err != nil {
 		return errors.Wrap(err, "reconcile sts")
 	}
@@ -218,6 +227,58 @@ func (r *PerconaServerForMySQLReconciler) reconcileDatabase(
 	}
 
 	return nil
+}
+
+func (r *PerconaServerForMySQLReconciler) reconcileMySQLConfiguration(
+	ctx context.Context,
+	cr *apiv2.PerconaServerForMySQL,
+) (string, error) {
+	l := log.FromContext(ctx).WithName("reconcileMySQLConfiguration")
+
+	cmName := mysql.ConfigMapName(cr)
+	nn := types.NamespacedName{Name: cmName, Namespace: cr.Namespace}
+
+	currCm := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, nn, currCm); err != nil && !k8serrors.IsNotFound(err) {
+		return "", errors.Wrapf(err, "get ConfigMap/%s", cmName)
+	}
+
+	// Cleanup if user removed the configuration from CR
+	if cr.Spec.MySQL.Configuration == "" {
+		exists, err := k8s.ObjectExists(ctx, r.Client, nn, currCm)
+		if err != nil {
+			return "", errors.Wrapf(err, "check if ConfigMap/%s exists", cmName)
+		}
+
+		if !exists || !metav1.IsControlledBy(currCm, cr) {
+			return "", nil
+		}
+
+		if err := r.Client.Delete(ctx, currCm); err != nil {
+			return "", errors.Wrapf(err, "delete ConfigMaps/%s", cmName)
+		}
+
+		l.Info("ConfigMap deleted", "name", cmName)
+
+		return "", nil
+	}
+
+	cm := k8s.ConfigMap(cmName, cr.Namespace, mysql.CustomConfigKey, cr.Spec.MySQL.Configuration)
+	if !reflect.DeepEqual(currCm.Data, cm.Data) {
+		if err := k8s.EnsureObject(ctx, r.Client, cr, cm, r.Scheme); err != nil {
+			return "", errors.Wrapf(err, "ensure ConfigMap/%s", cmName)
+		}
+
+		l.Info("ConfigMap updated", "name", cmName, "data", cm.Data)
+	}
+
+	d := struct{ Data map[string]string }{Data: cm.Data}
+	data, err := json.Marshal(d)
+	if err != nil {
+		return "", errors.Wrap(err, "marshal configmap data to json")
+	}
+
+	return fmt.Sprintf("%x", md5.Sum(data)), nil
 }
 
 func (r *PerconaServerForMySQLReconciler) reconcileOrchestrator(

--- a/e2e-tests/tests/sidecars/01-assert.yaml
+++ b/e2e-tests/tests/sidecars/01-assert.yaml
@@ -21,6 +21,8 @@ spec:
           name: users
         - mountPath: /etc/mysql/mysql-tls-secret
           name: tls
+        - mountPath: /etc/mysql/config
+          name: config
       - image: busybox
         imagePullPolicy: Always
         name: noop-memory
@@ -51,6 +53,22 @@ spec:
         secret:
           defaultMode: 420
           secretName: sidecar-test-ssl
+      - name: config
+        projected:
+          defaultMode: 420
+          sources:
+          - configMap:
+              items:
+              - key: my.cnf
+                path: my-config.cnf
+              name: sidecar-test-mysql
+              optional: true
+          - secret:
+              items:
+              - key: my.cnf
+                path: my-secret.cnf
+              name: sidecar-test-mysql
+              optional: true
       - emptyDir:
           medium: Memory
         name: memory-vol

--- a/pkg/k8s/configmap.go
+++ b/pkg/k8s/configmap.go
@@ -1,0 +1,22 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ConfigMap(name, namespace, filename, data string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			filename: data,
+		},
+	}
+}

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -11,15 +11,16 @@ import (
 )
 
 const (
-	componentName  = "mysql"
-	dataVolumeName = "datadir"
-	DataMountPath  = "/var/lib/mysql"
-	// configVolumeName = "config"
-	// configMountPath  = "/etc/mysql/config"
-	credsVolumeName = "users"
-	CredsMountPath  = "/etc/mysql/mysql-users-secret"
-	tlsVolumeName   = "tls"
-	tlsMountPath    = "/etc/mysql/mysql-tls-secret"
+	componentName    = "mysql"
+	dataVolumeName   = "datadir"
+	DataMountPath    = "/var/lib/mysql"
+	CustomConfigKey  = "my.cnf"
+	configVolumeName = "config"
+	configMountPath  = "/etc/mysql/config"
+	credsVolumeName  = "users"
+	CredsMountPath   = "/etc/mysql/mysql-users-secret"
+	tlsVolumeName    = "tls"
+	tlsMountPath     = "/etc/mysql/mysql-tls-secret"
 )
 
 const (
@@ -43,16 +44,24 @@ func UnreadyServiceName(cr *apiv2.PerconaServerForMySQL) string {
 	return Name(cr) + "-unready"
 }
 
+func ConfigMapName(cr *apiv2.PerconaServerForMySQL) string {
+	return Name(cr)
+}
+
 func MatchLabels(cr *apiv2.PerconaServerForMySQL) map[string]string {
 	return util.SSMapMerge(cr.MySQLSpec().Labels,
 		map[string]string{apiv2.ComponentLabel: componentName},
 		cr.Labels())
 }
 
-func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage string) *appsv1.StatefulSet {
+func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage, configHash string) *appsv1.StatefulSet {
 	labels := MatchLabels(cr)
 	spec := cr.MySQLSpec()
-	Replicas := spec.Size
+	replicas := spec.Size
+	t := true
+
+	annotations := make(map[string]string, 0)
+	annotations["percona.com/configuration-hash"] = configHash
 
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -65,7 +74,7 @@ func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage string) *appsv1.Stat
 			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: &Replicas,
+			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -73,7 +82,8 @@ func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage string) *appsv1.Stat
 			VolumeClaimTemplates: volumeClaimTemplates(spec),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
@@ -122,6 +132,43 @@ func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage string) *appsv1.Stat
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName: cr.Spec.SSLSecretName,
+									},
+								},
+							},
+							{
+								Name: configVolumeName,
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ConfigMap: &corev1.ConfigMapProjection{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: ConfigMapName(cr),
+													},
+													Items: []corev1.KeyToPath{
+														{
+															Key:  CustomConfigKey,
+															Path: "my-config.cnf",
+														},
+													},
+													Optional: &t,
+												},
+											},
+											{
+												Secret: &corev1.SecretProjection{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: ConfigMapName(cr),
+													},
+													Items: []corev1.KeyToPath{
+														{
+															Key:  CustomConfigKey,
+															Path: "my-secret.cnf",
+														},
+													},
+													Optional: &t,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -283,6 +330,10 @@ func mysqldContainer(cr *apiv2.PerconaServerForMySQL) corev1.Container {
 			{
 				Name:      tlsVolumeName,
 				MountPath: tlsMountPath,
+			},
+			{
+				Name:      configVolumeName,
+				MountPath: configMountPath,
 			},
 		},
 		Command:                  []string{"/var/lib/mysql/ps-entrypoint.sh"},

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -60,7 +60,7 @@ func StatefulSet(cr *apiv2.PerconaServerForMySQL, initImage, configHash string) 
 	replicas := spec.Size
 	t := true
 
-	annotations := make(map[string]string, 0)
+	annotations := make(map[string]string)
 	annotations["percona.com/configuration-hash"] = configHash
 
 	return &appsv1.StatefulSet{


### PR DESCRIPTION
We support three different ways to customize MySQL configuration:

1. `spec.mysql.configuration` field in `cr.yaml`. In this case, the operator will
   create the ConfigMap.
2. Creating a ConfigMap named `<cluster-name>-mysql` that contains the key `my.cnf`
3. Creating a Secret named `<cluster-name>-mysql` that contains the key `my.cnf`

We project ConfigMap and Secret in the same volume. In the entrypoint we
concat these files into MySQL config file (`/etc/my.cnf.d/node.cnf`). By
projecting these two resources, users will be able to split their
customizations. Sensitive values can live in the Secrets while the rest
live in the ConfigMap.

To automatically restart the MySQL pods on configuration change, we
calculate the md5 hash from the value of the `spec.mysql.configuration`
and store it in an annotation in the MySQL StatefulSet's PodSpec.
**This only applies to configuration in cr.yaml. Users need to restart
the MySQL pods if they create/update the configmap themselves.**