### PR TITLE
K8SPS-35: System users management

### DIFF
--- a/api/v2/perconaserverformysql_types.go
+++ b/api/v2/perconaserverformysql_types.go
@@ -390,6 +390,14 @@ func (cr *PerconaServerForMySQL) ClusterHash() string {
 	return serverIDHashStr
 }
 
+func (cr *PerconaServerForMySQL) InternalSecretName() string {
+	return "internal-" + cr.Name
+}
+
+func (cr *PerconaServerForMySQL) PMMEnabled() bool {
+	return cr.Spec.PMM != nil && cr.Spec.PMM.Enabled
+}
+
 func init() {
 	SchemeBuilder.Register(&PerconaServerForMySQL{}, &PerconaServerForMySQLList{})
 }

--- a/api/v2/perconaserverformysql_types.go
+++ b/api/v2/perconaserverformysql_types.go
@@ -340,6 +340,14 @@ func defaultPVCSpec(pvc *corev1.PersistentVolumeClaimSpec) {
 	}
 }
 
+type AnnotationKey string
+
+const (
+	AnnotationSpecHash   AnnotationKey = "percona.com/last-applied-spec"
+	AnnotationSecretHash AnnotationKey = "percona.com/last-applied-secret"
+	AnnotationConfigHash AnnotationKey = "percona.com/last-applied-config"
+)
+
 const (
 	NameLabel         = "app.kubernetes.io/name"
 	InstanceLabel     = "app.kubernetes.io/instance"

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -282,8 +282,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			CREATE USER 'operator'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${OPERATOR_ADMIN_PASSWORD}' ;
 			GRANT ALL ON *.* TO 'operator'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
 
-			CREATE USER 'xtrabackup'@'%' IDENTIFIED BY '${XTRABACKUP_PASSWORD}';
-			GRANT ALL ON *.* TO 'xtrabackup'@'%';
+			CREATE USER 'xtrabackup'@'localhost' IDENTIFIED BY '${XTRABACKUP_PASSWORD}';
+			GRANT ALL ON *.* TO 'xtrabackup'@'localhost';
 
 			CREATE USER 'monitor'@'${MONITOR_HOST}' IDENTIFIED BY '${MONITOR_PASSWORD}' WITH MAX_USER_CONNECTIONS 100;
 			GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'monitor'@'${MONITOR_HOST}';

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -283,21 +283,23 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			GRANT ALL ON *.* TO 'operator'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
 
 			CREATE USER 'xtrabackup'@'localhost' IDENTIFIED BY '${XTRABACKUP_PASSWORD}';
-			GRANT ALL ON *.* TO 'xtrabackup'@'localhost';
+			GRANT SYSTEM_USER, BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'xtrabackup'@'localhost';
+			GRANT SELECT ON performance_schema.log_status TO 'xtrabackup'@'localhost';
+			GRANT SELECT ON performance_schema.keyring_component_status TO 'xtrabackup'@'localhost';
 
 			CREATE USER 'monitor'@'${MONITOR_HOST}' IDENTIFIED BY '${MONITOR_PASSWORD}' WITH MAX_USER_CONNECTIONS 100;
-			GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'monitor'@'${MONITOR_HOST}';
+			GRANT SYSTEM_USER, SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD, BACKUP_ADMIN ON *.* TO 'monitor'@'${MONITOR_HOST}';
 			GRANT SELECT ON performance_schema.* TO 'monitor'@'${MONITOR_HOST}';
 			${monitorConnectGrant}
 
 			CREATE USER 'clustercheck'@'localhost' IDENTIFIED BY '${CLUSTERCHECK_PASSWORD}';
-			GRANT PROCESS ON *.* TO 'clustercheck'@'localhost';
+			GRANT SYSTEM_USER, PROCESS ON *.* TO 'clustercheck'@'localhost';
 
 			CREATE USER 'replication'@'%' IDENTIFIED BY '${REPLICATION_PASSWORD}';
-			GRANT REPLICATION SLAVE ON *.* to 'replication'@'%';
+			GRANT SYSTEM_USER, REPLICATION SLAVE ON *.* to 'replication'@'%';
 
 			CREATE USER 'orchestrator'@'%' IDENTIFIED BY '${ORC_TOPOLOGY_PASSWORD}';
-			GRANT SUPER, PROCESS, REPLICATION SLAVE, REPLICATION CLIENT, RELOAD ON *.* TO 'orchestrator'@'%';
+			GRANT SYSTEM_USER, SUPER, PROCESS, REPLICATION SLAVE, REPLICATION CLIENT, RELOAD ON *.* TO 'orchestrator'@'%';
 			GRANT SELECT ON mysql.slave_master_info TO 'orchestrator'@'%';
 			GRANT SELECT ON meta.* TO 'orchestrator'@'%';
 

--- a/controllers/perconaserverformysql_controller.go
+++ b/controllers/perconaserverformysql_controller.go
@@ -253,7 +253,7 @@ func (r *PerconaServerForMySQLReconciler) reconcileUsers(ctx context.Context, cr
 			restartOrchestrator = true
 		case apiv2.UserRoot:
 			mysqlUser.Hosts = append(mysqlUser.Hosts, "localhost")
-		case apiv2.UserClusterCheck:
+		case apiv2.UserClusterCheck, apiv2.UserXtraBackup:
 			mysqlUser.Hosts = []string{"localhost"}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 
+require golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+
 require (
 	cloud.google.com/go v0.54.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -19,25 +19,20 @@ func SecretKeySelector(name, key string) *corev1.SecretKeySelector {
 	}
 }
 
-func UserPassword(
-	ctx context.Context,
-	cl client.Reader,
-	cr *apiv2.PerconaServerForMySQL,
-	username apiv2.SystemUser,
-) (string, error) {
+func UserPassword(ctx context.Context, cl client.Reader, cr *apiv2.PerconaServerForMySQL, username apiv2.SystemUser) (string, error) {
 	nn := types.NamespacedName{
-		Name:      cr.Spec.SecretsName,
+		Name:      cr.InternalSecretName(),
 		Namespace: cr.Namespace,
 	}
 
 	secret := &corev1.Secret{}
 	if err := cl.Get(ctx, nn, secret); err != nil {
-		return "", errors.Wrapf(err, "get secret %s", cr.Spec.SecretsName)
+		return "", errors.Wrapf(err, "get secret/%s", nn.Name)
 	}
 
 	pass, ok := secret.Data[string(username)]
 	if !ok {
-		return "", errors.Errorf("no password for %s in secret %s", username, cr.Spec.SecretsName)
+		return "", errors.Errorf("no password for %s in secret %s", username, nn.Name)
 	}
 
 	return string(pass), nil

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -143,7 +142,7 @@ func EnsureObjectWithHash(
 	delete(objAnnotations, "percona.com/last-config-hash")
 	objectMeta.SetAnnotations(objAnnotations)
 
-	hash, err := getObjectHash(obj)
+	hash, err := ObjectHash(obj)
 	if err != nil {
 		return errors.Wrap(err, "calculate object hash")
 	}
@@ -196,21 +195,23 @@ func EnsureObjectWithHash(
 	return nil
 }
 
-func getObjectHash(obj runtime.Object) (string, error) {
-	var dataToMarshall interface{}
+func ObjectHash(obj runtime.Object) (string, error) {
+	var dataToMarshal interface{}
 
 	switch object := obj.(type) {
 	case *appsv1.StatefulSet:
-		dataToMarshall = object.Spec
+		dataToMarshal = object.Spec
 	case *appsv1.Deployment:
-		dataToMarshall = object.Spec
+		dataToMarshal = object.Spec
 	case *corev1.Service:
-		dataToMarshall = object.Spec
+		dataToMarshal = object.Spec
+	case *corev1.Secret:
+		dataToMarshal = object.Data
 	default:
-		dataToMarshall = obj
+		dataToMarshal = obj
 	}
 
-	data, err := json.Marshal(dataToMarshall)
+	data, err := json.Marshal(dataToMarshal)
 	if err != nil {
 		return "", err
 	}
@@ -252,7 +253,8 @@ func DefaultAPINamespace() (string, error) {
 	return strings.TrimSpace(string(nsBytes)), nil
 }
 
-func RolloutRestart(ctx context.Context, cl client.Client, obj runtime.Object) error {
+// RolloutRestart restarts pods owned by object by updating the pod template with passed annotation key-value.
+func RolloutRestart(ctx context.Context, cl client.Client, obj runtime.Object, key apiv2.AnnotationKey, value string) error {
 	switch obj := obj.(type) {
 	case *appsv1.StatefulSet:
 		orig := obj.DeepCopy()
@@ -260,7 +262,7 @@ func RolloutRestart(ctx context.Context, cl client.Client, obj runtime.Object) e
 		if obj.Spec.Template.ObjectMeta.Annotations == nil {
 			obj.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 		}
-		obj.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+		obj.Spec.Template.ObjectMeta.Annotations[string(key)] = value
 
 		if err := cl.Patch(ctx, obj, client.StrategicMergeFrom(orig)); err != nil {
 			return errors.Wrap(err, "patch object")

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	apiv2 "github.com/percona/percona-server-mysql-operator/api/v2"
 	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
@@ -28,8 +29,18 @@ const (
 	DefaultAdminPort = 33062
 )
 
+type User struct {
+	Username apiv2.SystemUser
+	Password string
+	Hosts    []string
+}
+
 func Name(cr *apiv2.PerconaServerForMySQL) string {
 	return cr.Name + "-" + componentName
+}
+
+func NamespacedName(cr *apiv2.PerconaServerForMySQL) types.NamespacedName {
+	return types.NamespacedName{Name: Name(cr), Namespace: cr.Namespace}
 }
 
 func ServiceName(cr *apiv2.PerconaServerForMySQL) string {

--- a/pkg/orchestrator/client.go
+++ b/pkg/orchestrator/client.go
@@ -77,6 +77,10 @@ func doRequest(ctx context.Context, url string, o interface{}) error {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode >= 400 && res.StatusCode <= 599 {
+		return errors.Errorf("request failed with %s", res.Status)
+	}
+
 	if err := json.NewDecoder(res.Body).Decode(o); err != nil {
 		return errors.Wrap(err, "json decode")
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -134,6 +134,10 @@ func container(cr *apiv2.PerconaServerForMySQL) corev1.Container {
 				Name:  "MYSQL_SERVICE",
 				Value: mysql.ServiceName(cr),
 			},
+			{
+				Name:  "RAFT_ENABLED",
+				Value: "false",
+			},
 		},
 		Ports: []corev1.ContainerPort{
 			{

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apiv2 "github.com/percona/percona-server-mysql-operator/api/v2"
@@ -32,6 +33,10 @@ const (
 // Name returns component name
 func Name(cr *apiv2.PerconaServerForMySQL) string {
 	return cr.Name + "-" + componentName
+}
+
+func NamespacedName(cr *apiv2.PerconaServerForMySQL) types.NamespacedName {
+	return types.NamespacedName{Name: Name(cr), Namespace: cr.Namespace}
 }
 
 func ServiceName(cr *apiv2.PerconaServerForMySQL) string {

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -187,15 +187,14 @@ func GeneratePasswordsSecret(name, namespace string) (*corev1.Secret, error) {
 		data[string(user)] = pass
 	}
 
-	secret := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,
-	}
-	return secret, nil
+	}, nil
 }
 
 // generatePass generates a random password

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -171,7 +171,6 @@ var secretUsers = [...]apiv2.SystemUser{
 	apiv2.UserXtraBackup,
 	apiv2.UserMonitor,
 	apiv2.UserClusterCheck,
-	apiv2.UserProxyAdmin,
 	apiv2.UserOperator,
 	apiv2.UserReplication,
 	apiv2.UserOrchestrator,

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -1,0 +1,74 @@
+package users
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
+
+	apiv2 "github.com/percona/percona-server-mysql-operator/api/v2"
+)
+
+type Manager interface {
+	UpdateUserPass(user apiv2.SystemUser, hosts []string, pass string) error
+	Close() error
+}
+
+type dbImpl struct{ db *sql.DB }
+
+func NewManager(user apiv2.SystemUser, pass, host string, port int32) (Manager, error) {
+	connStr := fmt.Sprintf("%s:%s@tcp(%s:%d)/performance_schema?interpolateParams=true",
+		user, pass, host, port)
+	db, err := sql.Open("mysql", connStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "connect to MySQL")
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, errors.Wrap(err, "ping database")
+	}
+
+	return &dbImpl{db}, nil
+}
+
+func (d *dbImpl) UpdateUserPass(user apiv2.SystemUser, hosts []string, pass string) error {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return errors.Wrap(err, "begin transaction")
+	}
+
+	for _, host := range hosts {
+		_, err = tx.Exec("ALTER USER ?@? IDENTIFIED BY ?", user, host, pass)
+		if err != nil {
+			err = errors.Wrap(err, "alter user")
+
+			if errT := tx.Rollback(); errT != nil {
+				return errors.Wrap(errors.Wrap(errT, "rollback"), err.Error())
+			}
+
+			return err
+		}
+	}
+
+	_, err = tx.Exec("FLUSH PRIVILEGES")
+	if err != nil {
+		err = errors.Wrap(err, "flush privileges")
+
+		if errT := tx.Rollback(); errT != nil {
+			return errors.Wrap(errors.Wrap(errT, "rollback"), err.Error())
+		}
+
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "commit transaction")
+	}
+
+	return nil
+}
+
+func (d *dbImpl) Close() error {
+	return d.db.Close()
+}

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,6 +199,9 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
+# golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
 ## explicit; go 1.17
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
We're depending on internal users secret for this feature as in PXC
operator. After user updates the secret object that referenced in
`cr.Spec.SecretsName`, the operator connects to MySQL **primary** and
runs `ALTER USER`. The connection is created using the old password in
the internal secret. If `ALTER USER` succeeds for all updated user
passwords, the internal secret object is updated with new values.

We have special cases for some users:
1. `monitor` user: If PMM is enabled, the operator restarts the MySQL
   pods.
2. `orchestrator` user: The operator restarts the Orchestrator pods.
3. `replication` user: The operator stops replication on each replica,
   updates the password, change replication password for the default
   channel and starts replication. The operator sends HTTP requests to
   orchestrator to stop/start replication since Orchestrator handles
   semi-sync replication too.
4. `root` user: We need to update password for both `root`@`%` and
   `root`@`localhost`.