### PR TITLE
Add example for custom configuration

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -22,29 +22,32 @@ spec:
           requests:
             storage: 2G
 
-#   sidecars:
-#   - name: noop-memory
-#     image: busybox
-#     command: ["sleep", "30d"]
-#     volumeMounts:
-#     - name: "memory-vol"
-#       mountPath: "/var/log/app/memory"
-#   - name: noop-pvc
-#     image: busybox
-#     command: ["sleep", "30d"]
-#     volumeMounts:
-#     - name: "pvc-vol"
-#       mountPath: "/var/log/app/pvc"
-#   sidecarVolumes:
-#   - name: "memory-vol"
-#     emptyDir:
-#       medium: "Memory"
-#   sidecarPVCs:
-#   - name: pvc-vol
-#     spec:
-#       resources:
-#         requests:
-#           storage: 1G
+#    configuration: |
+#      max_connections=250
+
+#    sidecars:
+#    - name: noop-memory
+#      image: busybox
+#      command: ["sleep", "30d"]
+#      volumeMounts:
+#      - name: "memory-vol"
+#        mountPath: "/var/log/app/memory"
+#    - name: noop-pvc
+#      image: busybox
+#      command: ["sleep", "30d"]
+#      volumeMounts:
+#      - name: "pvc-vol"
+#        mountPath: "/var/log/app/pvc"
+#    sidecarVolumes:
+#    - name: "memory-vol"
+#      emptyDir:
+#        medium: "Memory"
+#    sidecarPVCs:
+#    - name: pvc-vol
+#      spec:
+#        resources:
+#          requests:
+#            storage: 1G
 
   orchestrator:
     image: perconalab/percona-server-mysql-operator:main-orchestrator


### PR DESCRIPTION
Except for the custom config example I have move the sidecars example 1 space to the right so that if you just remove `#` with sed or something it will work (I think it's the same in PXC examples)