### PR TITLE
K8SPS-32: Orchestrator raft setup

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -239,10 +239,6 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(serverVersion *platform.ServerVe
 		return errors.New("mysql.sizeSemiSync can't be greater than or equal to mysql.size")
 	}
 
-	if cr.Spec.Orchestrator.Size > 1 {
-		return errors.New("orchestrator size must be 1")
-	}
-
 	if cr.Spec.MySQL.StartupProbe.InitialDelaySeconds == 0 {
 		cr.Spec.MySQL.StartupProbe.InitialDelaySeconds = 15
 	}

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -270,7 +270,7 @@ func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *a
 		return errors.Wrap(err, "get operator password")
 	}
 
-	orcHost := orchestrator.APIHost(orchestrator.ServiceName(cr))
+	orcHost := orchestrator.APIHost(cr)
 	primary, err := orchestrator.ClusterPrimary(ctx, orcHost, cr.ClusterHint())
 	if err != nil {
 		return errors.Wrap(err, "get cluster primary")
@@ -642,7 +642,7 @@ func reconcileReplicationPrimaryPod(
 	}
 	l.V(1).Info(fmt.Sprintf("got %v pods", len(pods)))
 
-	host := orchestrator.APIHost(orchestrator.ServiceName(cr))
+	host := orchestrator.APIHost(cr)
 	primary, err := orchestrator.ClusterPrimary(ctx, host, cr.ClusterHint())
 	if err != nil {
 		return errors.Wrap(err, "get cluster primary")
@@ -696,7 +696,7 @@ func reconcileReplicationSemiSync(
 ) error {
 	l := log.FromContext(ctx).WithName("reconcileReplicationSemiSync")
 
-	host := orchestrator.APIHost(orchestrator.ServiceName(cr))
+	host := orchestrator.APIHost(cr)
 	primary, err := orchestrator.ClusterPrimary(ctx, host, cr.ClusterHint())
 	if err != nil {
 		return errors.Wrap(err, "get cluster primary")

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -75,7 +75,20 @@ spec:
     image: perconalab/percona-server-mysql-operator:main-orchestrator
     imagePullPolicy: Always
 
-    size: 1
+    size: 3
+
+    affinity:
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+#      advanced:
+#        nodeAffinity:
+#          requiredDuringSchedulingIgnoredDuringExecution:
+#            nodeSelectorTerms:
+#            - matchExpressions:
+#              - key: kubernetes.io/e2e-az-name
+#                operator: In
+#                values:
+#                - e2e-az1
+#                - e2e-az2
 
     resources:
       requests:

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -65,7 +65,7 @@ get_cr() {
 		| yq eval '.spec.sslSecretName="test-ssl"' - \
 		| yq eval "$(printf '.spec.mysql.image="%s"' "${IMAGE_MYSQL}")" - \
 		| yq eval "$(printf '.spec.orchestrator.image="%s"' "${IMAGE_ORCHESTRATOR}")" - \
-		| yq eval "$(printf '.spec.pmm.image="%s"' "${IMAGE_MYSQL}")" -
+		| yq eval "$(printf '.spec.pmm.image="%s"' "${IMAGE_PMM}")" -
 }
 
 run_mysql() {
@@ -193,8 +193,8 @@ wait_cluster_consistency() {
 	fi
 
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
-	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" &&
-	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" &&
+	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" && \
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" && \
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.orchestrator.state}')" == "ready" ]]; do
 		echo 'waiting for cluster readyness'
 		sleep 15

--- a/e2e-tests/tests/init-deploy/01-assert.yaml
+++ b/e2e-tests/tests/init-deploy/01-assert.yaml
@@ -20,10 +20,10 @@ metadata:
   name: init-deploy-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
-  currentReplicas: 1
-  updatedReplicas: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
   collisionCount: 0
 ---
 apiVersion: ps.percona.com/v1alpha1
@@ -36,6 +36,6 @@ status:
     size: 3
     state: ready
   orchestrator:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
     state: ready

--- a/e2e-tests/tests/monitoring/02-assert.yaml
+++ b/e2e-tests/tests/monitoring/02-assert.yaml
@@ -26,10 +26,10 @@ metadata:
   name: monitoring-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
-  currentReplicas: 1
-  updatedReplicas: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
   collisionCount: 0
 ---
 apiVersion: ps.percona.com/v1alpha1
@@ -42,6 +42,6 @@ status:
     size: 3
     state: ready
   orchestrator:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
     state: ready

--- a/e2e-tests/tests/monitoring/02-create-cluster.yaml
+++ b/e2e-tests/tests/monitoring/02-create-cluster.yaml
@@ -1,40 +1,12 @@
-apiVersion: ps.percona.com/v1alpha1
-kind: PerconaServerMySQL
-metadata:
-  name: monitoring
-spec:
-  secretsName: test-secrets
-  sslSecretName: test-ssl
-  mysql:
-    image: percona/percona-server:8.0.25
-    imagePullPolicy: Always
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
 
-    size: 3
-    sizeSemiSync: 0
+      source ../../functions
 
-    volumeSpec:
-      persistentVolumeClaim:
-        resources:
-          requests:
-            storage: 2G
-
-  orchestrator:
-    image: perconalab/percona-server-mysql-operator:main-orchestrator
-    imagePullPolicy: Always
-
-    size: 1
-
-    volumeSpec:
-      persistentVolumeClaim:
-        resources:
-          requests:
-            storage: 1G
-
-  pmm:
-    enabled: true
-
-    image: percona/pmm-client:2.18.0
-    imagePullPolicy: Always
-
-    serverHost: monitoring-service
-    serverUser: admin
+      get_cr \
+      	| yq eval '.spec.pmm.enabled=true' - \
+      	| kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/semi-sync/01-assert.yaml
+++ b/e2e-tests/tests/semi-sync/01-assert.yaml
@@ -20,10 +20,10 @@ metadata:
   name: semi-sync-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
-  currentReplicas: 1
-  updatedReplicas: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
   collisionCount: 0
 ---
 apiVersion: ps.percona.com/v1alpha1
@@ -36,6 +36,6 @@ status:
     size: 3
     state: ready
   orchestrator:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
     state: ready

--- a/e2e-tests/tests/service-per-pod/01-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/01-assert.yaml
@@ -20,10 +20,10 @@ metadata:
   name: service-per-pod-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
-  currentReplicas: 1
-  updatedReplicas: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
   collisionCount: 0
 ---
 apiVersion: ps.percona.com/v1alpha1
@@ -36,8 +36,8 @@ status:
     size: 3
     state: ready
   orchestrator:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
     state: ready
 ---
 apiVersion: v1

--- a/e2e-tests/tests/service-per-pod/04-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/04-assert.yaml
@@ -20,10 +20,10 @@ metadata:
   name: service-per-pod-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
-  currentReplicas: 1
-  updatedReplicas: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
   collisionCount: 0
 ---
 apiVersion: ps.percona.com/v1alpha1
@@ -36,8 +36,8 @@ status:
     size: 3
     state: ready
   orchestrator:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
     state: ready
 ---
 apiVersion: v1

--- a/e2e-tests/tests/users/01-assert.yaml
+++ b/e2e-tests/tests/users/01-assert.yaml
@@ -19,5 +19,5 @@ metadata:
   name: users-orc
 status:
   observedGeneration: 1
-  replicas: 1
-  readyReplicas: 1
+  replicas: 3
+  readyReplicas: 3

--- a/e2e-tests/tests/users/03-assert.yaml
+++ b/e2e-tests/tests/users/03-assert.yaml
@@ -9,5 +9,5 @@ metadata:
   name: users-orc
 status:
   observedGeneration: 2
-  replicas: 1
-  readyReplicas: 1
+  replicas: 3
+  readyReplicas: 3

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -12,7 +12,7 @@ export VERSION=${VERSION:-$(echo "${GIT_BRANCH}" | sed -e 's^/^-^g; s^[.]^-^g;' 
 
 export IMAGE=${IMAGE:-"perconalab/percona-server-mysql-operator:${VERSION}"}
 export IMAGE_MYSQL=${IMAGE_MYSQL:-"perconalab/percona-server-mysql-operator:main-ps8.0"}
-export IMAGE_ORCHESTRATOR=${IMAGE_ORCHESTRATOR:-"perconalab/percona-server-mysql-operator:main-orchestrator"}
+export IMAGE_ORCHESTRATOR=${IMAGE_ORCHESTRATOR:-"perconalab/percona-server-mysql-operator:k8sps-32-orchestrator"}
 export IMAGE_PMM=${IMAGE_PMM:-"perconalab/pmm-client:dev-latest"}
 export PMM_SERVER_VERSION=${PMM_SERVER_VERSION:-$(curl https://raw.githubusercontent.com/Percona-Lab/percona-openshift/main/helm/pmm-server/Chart.yaml | awk '/^version/{print $NF}')}
 export IMAGE_PMM_SERVER_REPO="perconalab/pmm-server"


### PR DESCRIPTION
Accompanying PR: https://github.com/percona/percona-docker/pull/557

In the orchestrator entrypoint peers (`RaftNodes` in configuration) is
populated by using SRV records from orchestrator headless service. This
commit adds a new sidecar (`orc-monit`) to orchestrator pods that runs
`peer-list` to discover new orchestrator nodes. It restarts existing
orchestrator containers for every new orchestrator node to re-populate
the `RaftNodes`.

`orc-monit` restarts `orchestrator` process in the `orc` container. To
achieve this we enable `ShareProcessNamespace` for orchestrator pods.