### PR TITLE
K8SPS-66 - fix service-per-pod test and timeouts for OpenShift

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -168,6 +168,7 @@ get_service_ip() {
 		sleep 1
 	done
 	kubectl get service/$service -n "${NAMESPACE}" -o 'jsonpath={.status.loadBalancer.ingress[].ip}'
+	kubectl get service/$service -n "${NAMESPACE}" -o 'jsonpath={.status.loadBalancer.ingress[].hostname}'
 }
 
 wait_cluster_consistency() {

--- a/e2e-tests/tests/config/01-assert.yaml
+++ b/e2e-tests/tests/config/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 420
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/e2e-tests/tests/config/02-assert.yaml
+++ b/e2e-tests/tests/config/02-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 420
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/e2e-tests/tests/config/04-assert.yaml
+++ b/e2e-tests/tests/config/04-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 420
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/e2e-tests/tests/config/06-assert.yaml
+++ b/e2e-tests/tests/config/06-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 420
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/e2e-tests/tests/init-deploy/01-assert.yaml
+++ b/e2e-tests/tests/init-deploy/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 420
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/e2e-tests/tests/semi-sync/01-assert.yaml
+++ b/e2e-tests/tests/semi-sync/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 720
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/e2e-tests/tests/service-per-pod/01-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/01-assert.yaml
@@ -60,9 +60,6 @@ spec:
   clusterIP: None
   clusterIPs:
   - None
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -94,9 +91,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -132,9 +126,6 @@ spec:
   clusterIP: None
   clusterIPs:
   - None
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -168,9 +159,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -204,9 +192,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -240,9 +225,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306

--- a/e2e-tests/tests/service-per-pod/03-read-from-clusterip.yaml
+++ b/e2e-tests/tests/service-per-pod/03-read-from-clusterip.yaml
@@ -8,10 +8,10 @@ commands:
       source ../../functions
 
       args=''
-      size=$(kubectl -n ${NAMESPACE} get ps $(get_cluster_name) -o jsonpath='{.spec.mysql.size}')
+      size=$(kubectl -n ${NAMESPACE} get ps ${test_name} -o jsonpath='{.spec.mysql.size}')
       for i in $(seq 0 $((size - 1))); do
-        ip=$(get_service_ip service-per-pod-mysql-${i})
-      	host=$(get_mysql_headless_fqdn $(get_cluster_name) $i)
+      	ip=$(get_service_ip ${test_name}-mysql-${i})
+      	host=$(get_mysql_headless_fqdn ${test_name} $i)
       	data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${ip} -uroot -proot_password")
       	args="${args} --from-literal=${host}=${data}"
       done

--- a/e2e-tests/tests/service-per-pod/03-read-from-clusterip.yaml
+++ b/e2e-tests/tests/service-per-pod/03-read-from-clusterip.yaml
@@ -17,4 +17,4 @@ commands:
       done
 
       kubectl create configmap -n "${NAMESPACE}" 04-read-from-clusterip ${args}
-    timeout: 30
+    timeout: 60

--- a/e2e-tests/tests/service-per-pod/04-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/04-assert.yaml
@@ -60,9 +60,6 @@ spec:
   clusterIP: None
   clusterIPs:
   - None
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -94,9 +91,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -132,9 +126,6 @@ spec:
   clusterIP: None
   clusterIPs:
   - None
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -168,9 +159,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -204,9 +192,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306
@@ -240,9 +225,6 @@ metadata:
     kind: PerconaServerMySQL
     name: service-per-pod
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: mysql
     port: 3306

--- a/e2e-tests/tests/service-per-pod/05-read-from-loadbalancer.yaml
+++ b/e2e-tests/tests/service-per-pod/05-read-from-loadbalancer.yaml
@@ -9,10 +9,10 @@ commands:
 
       args=''
       size=$(kubectl -n ${NAMESPACE} get ps ${test_name} -o jsonpath='{.spec.mysql.size}')
+      sleep 75
       for i in $(seq 0 $((size - 1))); do
-        ip=$(get_service_ip service-per-pod-mysql-$i)
-      	host=$(get_mysql_headless_fqdn $(get_cluster_name) $i)
-        sleep 10
+      	ip=$(get_service_ip ${test_name}-mysql-$i)
+      	host=$(get_mysql_headless_fqdn ${test_name} $i)
       	data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${ip} -uroot -proot_password")
       	args="${args} --from-literal=${host}=${data}"
       done

--- a/e2e-tests/tests/service-per-pod/05-read-from-loadbalancer.yaml
+++ b/e2e-tests/tests/service-per-pod/05-read-from-loadbalancer.yaml
@@ -8,7 +8,7 @@ commands:
       source ../../functions
 
       args=''
-      size=$(kubectl -n ${NAMESPACE} get ps $(get_cluster_name) -o jsonpath='{.spec.mysql.size}')
+      size=$(kubectl -n ${NAMESPACE} get ps ${test_name} -o jsonpath='{.spec.mysql.size}')
       for i in $(seq 0 $((size - 1))); do
         ip=$(get_service_ip service-per-pod-mysql-$i)
       	host=$(get_mysql_headless_fqdn $(get_cluster_name) $i)

--- a/e2e-tests/tests/users/04-check-cluster.yaml
+++ b/e2e-tests/tests/users/04-check-cluster.yaml
@@ -49,4 +49,4 @@ commands:
       	| sed 's/ *//')
 
       kubectl create configmap -n "${NAMESPACE}" 04-check-replication --from-literal=replicating="${replicating}"
-    timeout: 120
+    timeout: 180


### PR DESCRIPTION
TEST RESULTS:
GKE: https://cloud.cd.percona.com/view/PSO/job/ps-operator-gke-version/41/
EKS: https://cloud.cd.percona.com/view/PSO/job/ps-operator-eks/36/
OpenShift: https://cloud.cd.percona.com/view/PSO/job/ps-operator-aws-openshift-4/31/