### PR TITLE
K8SPS-70: Fix changing CR secret name with new passwords

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -179,6 +179,7 @@ type PerconaServerMySQLStatus struct { // INSERT ADDITIONAL STATUS FIELD - defin
 	// Important: Run "make" to regenerate code after modifying this file
 	MySQL        StatefulAppStatus `json:"mysql,omitempty"`
 	Orchestrator StatefulAppStatus `json:"orchestrator,omitempty"`
+	State        StatefulAppState  `json:"state,omitempty"`
 }
 
 // PerconaServerMySQL is the Schema for the perconaservermysqls API
@@ -186,6 +187,7 @@ type PerconaServerMySQLStatus struct { // INSERT ADDITIONAL STATUS FIELD - defin
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="MySQL",type=string,JSONPath=".status.mysql.state"
 //+kubebuilder:printcolumn:name="Orchestrator",type=string,JSONPath=".status.orchestrator.state"
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=".status.state"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:resource:scope=Namespaced
 //+kubebuilder:resource:shortName=ps

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -270,6 +270,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		file_env 'REPLICATION_PASSWORD' '' 'replication'
 		file_env 'ORC_TOPOLOGY_PASSWORD' '' 'orchestrator'
 		file_env 'OPERATOR_ADMIN_PASSWORD' '' 'operator'
+		file_env 'XTRABACKUP_PASSWORD' '' 'xtrabackup'
 		read -r -d '' monitorConnectGrant <<-EOSQL || true
 			GRANT SERVICE_CONNECTION_ADMIN ON *.* TO 'monitor'@'${MONITOR_HOST}';
 		EOSQL

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -41,7 +41,7 @@ func checkReadiness() error {
 		return errors.Wrapf(err, "get %s password", apiv1alpha1.UserOperator)
 	}
 
-	db, err := replicator.NewReplicator("operator", operatorPass, podIP, mysql.DefaultAdminPort)
+	db, err := replicator.NewReplicator(apiv1alpha1.UserOperator, operatorPass, podIP, mysql.DefaultAdminPort)
 	if err != nil {
 		return errors.Wrap(err, "connect to db")
 	}

--- a/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
+++ b/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
@@ -25,6 +25,9 @@ spec:
     - jsonPath: .status.orchestrator.state
       name: Orchestrator
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -7204,6 +7207,8 @@ spec:
                   state:
                     type: string
                 type: object
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -249,7 +249,7 @@ func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *a
 			restartMySQL = cr.PMMEnabled()
 		case apiv1alpha1.UserPMMServer:
 			restartMySQL = cr.PMMEnabled()
-			continue
+			continue  // PMM server user credentials are not stored in db
 		case apiv1alpha1.UserReplication:
 			restartReplication = true
 		case apiv1alpha1.UserOrchestrator:
@@ -334,7 +334,7 @@ func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *a
 	}
 
 	if err := um.UpdateUserPasswords(updatedUsers); err != nil {
-		return errors.Wrapf(err, "update orchestrator password")
+		return errors.Wrapf(err, "update passwords")
 	}
 
 	if restartReplication {
@@ -405,10 +405,23 @@ func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *a
 		}
 	}
 
+	if cr.Status.State != apiv1alpha1.StateReady {
+		l.Info("Waiting cluster to be ready")
+		return nil
+	}
+
+	if err := um.DiscardOldPasswords(updatedUsers); err != nil {
+		return errors.Wrap(err, "discard old passwords")
+	}
+
+	l.Info("Discarded old user passwords")
+
 	internalSecret.Data = secret.Data
 	if err := r.Client.Update(ctx, internalSecret); err != nil {
 		return errors.Wrapf(err, "update Secret/%s", internalSecret.Name)
 	}
+
+	l.Info("Updated internal secret", "secretName", cr.InternalSecretName())
 
 	return nil
 }

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -249,7 +249,7 @@ func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *a
 			restartMySQL = cr.PMMEnabled()
 		case apiv1alpha1.UserPMMServer:
 			restartMySQL = cr.PMMEnabled()
-			continue  // PMM server user credentials are not stored in db
+			continue // PMM server user credentials are not stored in db
 		case apiv1alpha1.UserReplication:
 			restartReplication = true
 		case apiv1alpha1.UserOrchestrator:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -145,6 +145,9 @@ spec:
     - jsonPath: .status.orchestrator.state
       name: Orchestrator
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -7324,6 +7327,8 @@ spec:
                   state:
                     type: string
                 type: object
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -145,6 +145,9 @@ spec:
     - jsonPath: .status.orchestrator.state
       name: Orchestrator
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -7324,6 +7327,8 @@ spec:
                   state:
                     type: string
                 type: object
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -178,8 +178,8 @@ wait_cluster_consistency() {
 	fi
 
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
-	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" && \
-	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" && \
+	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" &&
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" &&
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.orchestrator.state}')" == "ready" ]]; do
 		echo 'waiting for cluster readyness'
 		sleep 15

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -178,8 +178,8 @@ wait_cluster_consistency() {
 	fi
 
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
-	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" &&
-	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" &&
+	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" && \
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" && \
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.orchestrator.state}')" == "ready" ]]; do
 		echo 'waiting for cluster readyness'
 		sleep 15

--- a/e2e-tests/tests/service-per-pod/01-create-cluster-clusterip.yaml
+++ b/e2e-tests/tests/service-per-pod/01-create-cluster-clusterip.yaml
@@ -8,7 +8,7 @@ commands:
       source ../../functions
 
       get_cr \
-      | yq eval '.spec.mysql.expose.enabled = true' - \
-      | yq eval '.spec.mysql.expose.type = "ClusterIP"' - \
-      | kubectl -n "${NAMESPACE}" apply -f -
+      	| yq eval '.spec.mysql.expose.enabled = true' - \
+      	| yq eval '.spec.mysql.expose.type = "ClusterIP"' - \
+      	| kubectl -n "${NAMESPACE}" apply -f -
     timeout: 10

--- a/e2e-tests/tests/service-per-pod/04-create-cluster-loadbalancer.yaml
+++ b/e2e-tests/tests/service-per-pod/04-create-cluster-loadbalancer.yaml
@@ -8,7 +8,7 @@ commands:
       source ../../functions
 
       get_cr \
-      | yq eval '.spec.mysql.expose.enabled = true' - \
-      | yq eval '.spec.mysql.expose.type = "LoadBalancer"' - \
-      | kubectl -n "${NAMESPACE}" apply -f -
+      	| yq eval '.spec.mysql.expose.enabled = true' - \
+      	| yq eval '.spec.mysql.expose.type = "LoadBalancer"' - \
+      	| kubectl -n "${NAMESPACE}" apply -f -
     timeout: 10

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -138,7 +138,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL, initImage, configHash strin
 								Name: credsVolumeName,
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: cr.Spec.SecretsName,
+										SecretName: cr.InternalSecretName(),
 									},
 								},
 							},

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -99,7 +99,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL) *appsv1.StatefulSet {
 							Name: credsVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: cr.Spec.SecretsName,
+									SecretName: cr.InternalSecretName(),
 								},
 							},
 						},


### PR DESCRIPTION
If the user changes spec.secretsName and the new secret object contains
updated passwords, MySQL probes start to fail and cluster crashes. We
were mounting the secret referenced in spec.secretsName, with this
commit we mount the internal secret to MySQL and Orchestrator pods.

Also, we're now using the dual password feature that introduced in MySQL 8.
We update the user passwords with `RETAIN CURRENT PASSWORD` and discard
the old passwords after the cluster becomes stable after restarts.