### PR TITLE
K8SPS-41: Use super_read_only

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -174,6 +174,10 @@ create_default_cnf() {
 	done
 }
 
+enable_super_read_only() {
+	sed -i "/\[mysqld\]/a super_read_only=ON" $CFG
+}
+
 MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 if [ "$MYSQL_VERSION" != '8.0' ]; then
@@ -361,6 +365,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+
+	enable_super_read_only
 
 	# exit when MYSQL_INIT_ONLY environment variable is set to avoid starting mysqld
 	if [ ! -z "$MYSQL_INIT_ONLY" ]; then


### PR DESCRIPTION
We're adding super_read_only to the MySQL config after initialization
completed because it interferes with initialization procedure.