### PR TITLE
Build custom resource locally 

### DIFF
--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -20,6 +20,8 @@ export IMAGE_PMM_SERVER_TAG="dev-latest"
 
 date=$(which gdate || which date)
 
-if oc get projects; then
-	export OPENSHIFT=4
+if command -v oc &> /dev/null; then
+	if oc get projects; then
+		export OPENSHIFT=4
+	fi
 fi


### PR DESCRIPTION
Hi,
there is no description how to build the operator and have CRs visible in K8s (minikube). 
I tried to do some tweaks and output is successful
<details> <summary> Before patch </summary> 
<pre>
$ make
/home/anel/percona/percona-server-mysql-operator/bin/controller-gen crd rbac:roleName=percona-server-mysql-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases  ## Generate WebhookConfiguration, Role and CustomResourceDefinition objects.
/home/anel/percona/percona-server-mysql-operator/bin/controller-gen object:headerFile="LICENSE-HEADER" paths="./..." ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
ROOT_REPO=/home/anel/percona/percona-server-mysql-operator VERSION=anel-try-to-build /home/anel/percona/percona-server-mysql-operator/e2e-tests/build
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   500  100   500    0     0   1766      0 --:--:-- --:--:-- --:--:--  1760
~/percona/percona-server-mysql-operator ~/percona/percona-server-mysql-operator
"--squash" is only supported on a Docker daemon with experimental features enabled
~/percona/percona-server-mysql-operator
The push refers to repository [docker.io/perconalab/percona-server-mysql-operator]
tag does not exist: perconalab/percona-server-m
</pre>
</details>
<details><summary>Build with patch</summary>
    <pre>
$ make install
/home/anel/percona/percona-server-mysql-operator/bin/controller-gen crd rbac:roleName=percona-server-mysql-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases  ## Generate WebhookConfiguration, Role and CustomResourceDefinition objects.
/home/anel/percona/percona-server-mysql-operator/bin/controller-gen object:headerFile="LICENSE-HEADER" paths="./..." ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
/home/anel/percona/percona-server-mysql-operator/bin/kustomize build config/crd/ > ./deploy/crd.yaml
echo "---" >> ./deploy/crd.yaml
/home/anel/percona/percona-server-mysql-operator/bin/kustomize build config/rbac/ | sed 's/ClusterRole/Role/g' > ./deploy/rbac.yaml
echo "---" >> ./deploy/rbac.yaml
cd config/manager && /home/anel/percona/percona-server-mysql-operator/bin/kustomize edit set image perconalab/percona-server-mysql-operator=perconalab/percona-server-mysql-operator:anel-try-to-build
/home/anel/percona/percona-server-mysql-operator/bin/kustomize build config/manager/ > ./deploy/operator.yaml
echo "---" >> ./deploy/operator.yaml
cat ./deploy/crd.yaml ./deploy/rbac.yaml ./deploy/operator.yaml > ./deploy/bundle.yaml
kubectl apply -f ./deploy/crd.yaml
customresourcedefinition.apiextensions.k8s.io/perconaservermysqlbackups.ps.percona.com created
customresourcedefinition.apiextensions.k8s.io/perconaservermysqlrestores.ps.percona.com created
customresourcedefinition.apiextensions.k8s.io/perconaservermysqls.ps.percona.com created
kubectl apply -f ./deploy/rbac.yaml
serviceaccount/percona-server-mysql-operator created
role.rbac.authorization.k8s.io/percona-server-mysql-operator-leaderelection created
role.rbac.authorization.k8s.io/percona-server-mysql-operator created
rolebinding.rbac.authorization.k8s.io/percona-server-mysql-operator-leaderelection created
rolebinding.rbac.authorization.k8s.io/percona-server-mysql-operator created
    </pre>
  </details>

<details><summary>Show CRDs after build</summary>
    <pre>
$ kubectl get crds -o wide
NAME                                        CREATED AT
perconaservermysqlbackups.ps.percona.com    2022-06-08T11:56:33Z
perconaservermysqlrestores.ps.percona.com   2022-06-08T11:56:33Z
perconaservermysqls.ps.percona.com          2022-06-08T11:56:33Z
    </pre>
   </details>