### PR TITLE
K8SPS-53 - Improve demand-backup test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ pipeline {
 
                     kubectl krew install kuttl
                 '''
-                withCredentials([file(credentialsId: 'cloud-secret-file', variable: 'CLOUD_SECRET_FILE')]) {
+                withCredentials([file(credentialsId: 'cloud-secret-file-ps', variable: 'CLOUD_SECRET_FILE')]) {
                     sh 'cp $CLOUD_SECRET_FILE e2e-tests/conf/cloud-secret.yml'
                 }
             }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -21,6 +21,11 @@ deploy_client() {
 	kubectl -n "${NAMESPACE}" apply -f "${TESTS_CONFIG_DIR}/client.yaml"
 }
 
+apply_s3_storage_secrets() {
+	kubectl -n "${NAMESPACE}" apply -f "${TESTS_CONFIG_DIR}/minio-secret.yml"
+	kubectl -n "${NAMESPACE}" apply -f "${TESTS_CONFIG_DIR}/cloud-secret.yml"
+}
+
 deploy_pmm_server() {
 	local platform=kubernetes
 	if [ -n "${OPENSHIFT}" ]; then

--- a/e2e-tests/tests/demand-backup/00-deploy-operator.yaml
+++ b/e2e-tests/tests/demand-backup/00-deploy-operator.yaml
@@ -7,6 +7,7 @@ commands:
 
       source ../../functions
 
+      apply_s3_storage_secrets
       deploy_operator
       deploy_client
       deploy_minio

--- a/e2e-tests/tests/demand-backup/01-create-cluster.yaml
+++ b/e2e-tests/tests/demand-backup/01-create-cluster.yaml
@@ -9,9 +9,23 @@ commands:
       source ../../functions
 
       get_cr \
-      	| yq eval '.spec.backup.storages.us-east-1.type="s3"' - \
-      	| yq eval '.spec.backup.storages.us-east-1.s3.bucket="operator-testing"' - \
-      	| yq eval '.spec.backup.storages.us-east-1.s3.credentialsSecret="minio-secret"' - \
-      	| yq eval '.spec.backup.storages.us-east-1.s3.endpointUrl="http://minio-service:9000"' - \
-      	| yq eval '.spec.backup.storages.us-east-1.s3.region="us-east-1"' - \
+      	| yq eval '.spec.backup.storages.minio.type="s3"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.bucket="operator-testing"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.credentialsSecret="minio-secret"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.endpointUrl="http://minio-service:9000"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.region="us-east-1"' - \
+      	| yq eval '.spec.backup.storages.aws-s3.type="s3"' - \
+      	| yq eval '.spec.backup.storages.aws-s3.verifyTLS=true' - \
+      	| yq eval '.spec.backup.storages.aws-s3.s3.bucket="operator-testing"' - \
+      	| yq eval '.spec.backup.storages.aws-s3.s3.credentialsSecret="aws-s3-secret"' - \
+      	| yq eval '.spec.backup.storages.aws-s3.s3.region="us-east-1"' - \
+      	| yq eval '.spec.backup.storages.gcp-cs.type="gcs"' - \
+      	| yq eval '.spec.backup.storages.gcp-cs.verifyTLS=true' - \
+      	| yq eval '.spec.backup.storages.gcp-cs.gcs.bucket="operator-testing"' - \
+      	| yq eval '.spec.backup.storages.gcp-cs.gcs.credentialsSecret="gcp-cs-secret"' - \
+      	| yq eval '.spec.backup.storages.gcp-cs.gcs.endpointUrl="https://storage.googleapis.com"' - \
+      	| yq eval '.spec.backup.storages.azure-blob.type="azure"' - \
+      	| yq eval '.spec.backup.storages.azure-blob.verifyTLS=true' - \
+      	| yq eval '.spec.backup.storages.azure-blob.azure.containerName="operator-testing"' - \
+      	| yq eval '.spec.backup.storages.azure-blob.azure.credentialsSecret="azure-secret"' - \
       	| kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/demand-backup/03-assert.yaml
+++ b/e2e-tests/tests/demand-backup/03-assert.yaml
@@ -5,6 +5,6 @@ timeout: 300
 kind: PerconaServerMySQLBackup
 apiVersion: ps.percona.com/v1alpha1
 metadata:
-  name: demand-backup-1
+  name: demand-backup-minio
 status:
   state: Succeeded

--- a/e2e-tests/tests/demand-backup/03-create-backup-minio.yaml
+++ b/e2e-tests/tests/demand-backup/03-create-backup-minio.yaml
@@ -9,7 +9,7 @@ stringData:
 apiVersion: ps.percona.com/v1alpha1
 kind: PerconaServerMySQLBackup
 metadata:
-  name: demand-backup-1
+  name: demand-backup-minio
 spec:
   clusterName: demand-backup
   storageName: us-east-1

--- a/e2e-tests/tests/demand-backup/04-assert.yaml
+++ b/e2e-tests/tests/demand-backup/04-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-0
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-1
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-2
+data:
+  data: ""

--- a/e2e-tests/tests/demand-backup/05-assert.yaml
+++ b/e2e-tests/tests/demand-backup/05-assert.yaml
@@ -19,6 +19,6 @@ status:
 kind: PerconaServerMySQLRestore
 apiVersion: ps.percona.com/v1alpha1
 metadata:
-  name: demand-backup-restore-1
+  name: demand-backup-restore-minio
 status:
   state: Succeeded

--- a/e2e-tests/tests/demand-backup/05-restore-from-minio.yaml
+++ b/e2e-tests/tests/demand-backup/05-restore-from-minio.yaml
@@ -1,7 +1,7 @@
 apiVersion: ps.percona.com/v1alpha1
 kind: PerconaServerMySQLRestore
 metadata:
-  name: demand-backup-restore-1
+  name: demand-backup-restore-minio
 spec:
   clusterName: demand-backup
-  backupName: demand-backup-1
+  backupName: demand-backup-minio

--- a/e2e-tests/tests/demand-backup/06-assert.yaml
+++ b/e2e-tests/tests/demand-backup/06-assert.yaml
@@ -5,6 +5,20 @@ timeout: 30
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: 06-read-data
+  name: 06-read-data-minio-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio-2
 data:
   data: "100500"

--- a/e2e-tests/tests/demand-backup/06-read-data.yaml
+++ b/e2e-tests/tests/demand-backup/06-read-data.yaml
@@ -8,6 +8,9 @@ commands:
 
       source ../../functions
 
-      data=$(run_mysql "SELECT * FROM myDB.myTable" "-h $(get_mysql_primary_service $(get_cluster_name)) -uroot -proot_password")
-
-      kubectl create configmap -n "${NAMESPACE}" 06-read-data --from-literal=data="${data}"
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2
+      do
+        data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
+        kubectl create configmap -n "${NAMESPACE}" 06-read-data-minio-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/demand-backup/07-assert.yaml
+++ b/e2e-tests/tests/demand-backup/07-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: PerconaServerMySQLBackup
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-s3
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/07-create-backup-s3.yaml
+++ b/e2e-tests/tests/demand-backup/07-create-backup-s3.yaml
@@ -1,7 +1,7 @@
 apiVersion: ps.percona.com/v1alpha1
 kind: PerconaServerMySQLBackup
 metadata:
-  name: demand-backup-minio
+  name: demand-backup-s3
 spec:
   clusterName: demand-backup
-  storageName: minio
+  storageName: aws-s3

--- a/e2e-tests/tests/demand-backup/08-assert.yaml
+++ b/e2e-tests/tests/demand-backup/08-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 08-delete-data-s3-0
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 08-delete-data-s3-1
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 08-delete-data-s3-2
+data:
+  data: ""

--- a/e2e-tests/tests/demand-backup/08-delete-data.yaml
+++ b/e2e-tests/tests/demand-backup/08-delete-data.yaml
@@ -15,5 +15,5 @@ commands:
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 08-delete-data-s3-${i} --from-literal=data="${data}"
       done

--- a/e2e-tests/tests/demand-backup/09-assert.yaml
+++ b/e2e-tests/tests/demand-backup/09-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 360
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: demand-backup
+status:
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  orchestrator:
+    ready: 3
+    size: 3
+    state: ready
+---
+kind: PerconaServerMySQLRestore
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-restore-s3
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/09-restore-from-s3.yaml
+++ b/e2e-tests/tests/demand-backup/09-restore-from-s3.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLRestore
+metadata:
+  name: demand-backup-restore-s3
+spec:
+  clusterName: demand-backup
+  backupName: demand-backup-s3

--- a/e2e-tests/tests/demand-backup/10-assert.yaml
+++ b/e2e-tests/tests/demand-backup/10-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-s3-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-s3-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-s3-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/demand-backup/10-read-data.yaml
+++ b/e2e-tests/tests/demand-backup/10-read-data.yaml
@@ -1,5 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
+timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -7,13 +8,9 @@ commands:
 
       source ../../functions
 
-      run_mysql \
-      	"TRUNCATE TABLE myDB.myTable" \
-      	"-h $(get_mysql_primary_service $(get_cluster_name)) -uroot -proot_password"
-
       cluster_name=$(get_cluster_name)
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 06-read-data-s3-${i} --from-literal=data="${data}"
       done

--- a/e2e-tests/tests/demand-backup/11-assert.yaml
+++ b/e2e-tests/tests/demand-backup/11-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: PerconaServerMySQLBackup
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-gcp
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/11-create-backup-gcp.yaml
+++ b/e2e-tests/tests/demand-backup/11-create-backup-gcp.yaml
@@ -1,7 +1,7 @@
 apiVersion: ps.percona.com/v1alpha1
 kind: PerconaServerMySQLBackup
 metadata:
-  name: demand-backup-minio
+  name: demand-backup-gcp
 spec:
   clusterName: demand-backup
-  storageName: minio
+  storageName: gcp-cs

--- a/e2e-tests/tests/demand-backup/12-assert.yaml
+++ b/e2e-tests/tests/demand-backup/12-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 12-delete-data-gcp-0
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 12-delete-data-gcp-1
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 12-delete-data-gcp-2
+data:
+  data: ""

--- a/e2e-tests/tests/demand-backup/12-delete-data.yaml
+++ b/e2e-tests/tests/demand-backup/12-delete-data.yaml
@@ -15,5 +15,5 @@ commands:
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 12-delete-data-gcp-${i} --from-literal=data="${data}"
       done

--- a/e2e-tests/tests/demand-backup/13-assert.yaml
+++ b/e2e-tests/tests/demand-backup/13-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 360
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: demand-backup
+status:
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  orchestrator:
+    ready: 3
+    size: 3
+    state: ready
+---
+kind: PerconaServerMySQLRestore
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-restore-gcp
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/13-restore-from-gcp.yaml
+++ b/e2e-tests/tests/demand-backup/13-restore-from-gcp.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLRestore
+metadata:
+  name: demand-backup-restore-gcp
+spec:
+  clusterName: demand-backup
+  backupName: demand-backup-gcp

--- a/e2e-tests/tests/demand-backup/14-assert.yaml
+++ b/e2e-tests/tests/demand-backup/14-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-gcp-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-gcp-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-gcp-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/demand-backup/14-read-data.yaml
+++ b/e2e-tests/tests/demand-backup/14-read-data.yaml
@@ -1,5 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
+timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -7,13 +8,9 @@ commands:
 
       source ../../functions
 
-      run_mysql \
-      	"TRUNCATE TABLE myDB.myTable" \
-      	"-h $(get_mysql_primary_service $(get_cluster_name)) -uroot -proot_password"
-
       cluster_name=$(get_cluster_name)
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 06-read-data-gcp-${i} --from-literal=data="${data}"
       done

--- a/e2e-tests/tests/demand-backup/15-assert.yaml
+++ b/e2e-tests/tests/demand-backup/15-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: PerconaServerMySQLBackup
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-azure
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/15-create-backup-azure.yaml
+++ b/e2e-tests/tests/demand-backup/15-create-backup-azure.yaml
@@ -1,7 +1,7 @@
 apiVersion: ps.percona.com/v1alpha1
 kind: PerconaServerMySQLBackup
 metadata:
-  name: demand-backup-minio
+  name: demand-backup-azure
 spec:
   clusterName: demand-backup
-  storageName: minio
+  storageName: azure-blob

--- a/e2e-tests/tests/demand-backup/16-assert.yaml
+++ b/e2e-tests/tests/demand-backup/16-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 16-delete-data-azure-0
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 16-delete-data-azure-1
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 16-delete-data-azure-2
+data:
+  data: ""

--- a/e2e-tests/tests/demand-backup/16-delete-data.yaml
+++ b/e2e-tests/tests/demand-backup/16-delete-data.yaml
@@ -15,5 +15,5 @@ commands:
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 16-delete-data-azure-${i} --from-literal=data="${data}"
       done

--- a/e2e-tests/tests/demand-backup/17-assert.yaml
+++ b/e2e-tests/tests/demand-backup/17-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 360
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: demand-backup
+status:
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  orchestrator:
+    ready: 3
+    size: 3
+    state: ready
+---
+kind: PerconaServerMySQLRestore
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: demand-backup-restore-azure
+status:
+  state: Succeeded

--- a/e2e-tests/tests/demand-backup/17-restore-from-azure.yaml
+++ b/e2e-tests/tests/demand-backup/17-restore-from-azure.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLRestore
+metadata:
+  name: demand-backup-restore-azure
+spec:
+  clusterName: demand-backup
+  backupName: demand-backup-azure

--- a/e2e-tests/tests/demand-backup/18-assert.yaml
+++ b/e2e-tests/tests/demand-backup/18-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-azure-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-azure-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-azure-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/demand-backup/18-read-data.yaml
+++ b/e2e-tests/tests/demand-backup/18-read-data.yaml
@@ -1,5 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
+timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -7,13 +8,9 @@ commands:
 
       source ../../functions
 
-      run_mysql \
-      	"TRUNCATE TABLE myDB.myTable" \
-      	"-h $(get_mysql_primary_service $(get_cluster_name)) -uroot -proot_password"
-
       cluster_name=$(get_cluster_name)
       for i in 0 1 2
       do
         data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
-        kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+        kubectl create configmap -n "${NAMESPACE}" 06-read-data-azure-${i} --from-literal=data="${data}"
       done


### PR DESCRIPTION
This adds:
- azure, gcp and s3 test steps
- checks the data in all nodes instead of just one
- adds a check for data delete step
- change cloud secret in Jenkinsfile because the one for PS is different than for other operators