### PR TITLE
K8SPS-104 add '--target-dir' option for xtrabackup

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -103,6 +103,7 @@ func xtrabackupArgs(user, pass string) []string {
 		"--stream=xbstream",
 		"--safe-slave-backup",
 		"--slave-info",
+		"--target-dir=/backup/",
 		fmt.Sprintf("--user=%s", user),
 		fmt.Sprintf("--password=%s", pass),
 	}

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -146,7 +146,7 @@ spec:
 
   backup:
     enabled: true
-    image: percona/percona-xtrabackup:8.0.28
+    image: perconalab/percona-server-mysql-operator:main-backup
     imagePullPolicy: Always
     storages:
       s3-us-west:


### PR DESCRIPTION
    * add '--target-dir' option for xtrabackup to avoid the
      following error 'cannot mkdir: 13 /xtrabackup_backupfiles/'
      in case xtrabackup is not running under the root