### PR TITLE
Set DOCKER_DEFAULT_PLATFORM to linux/amd64 in the build script

### DIFF
--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -24,6 +24,7 @@ build_operator() {
 		GO_LDFLAGS="-race"
 	fi
 
+	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
 	export GO_LDFLAGS="-w -s -trimpath ${GO_LDFLAGS}"
 	pushd "${ROOT_REPO}" || exit
 	docker build \


### PR DESCRIPTION
This fixes default build on M1 Mac for example.