### PR TITLE
Add commented out prefix field to CR.

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -188,4 +188,5 @@ spec:
           bucket: S3-BACKUP-BUCKET-NAME-HERE
           credentialsSecret: cluster1-s3-credentials
           region: us-west-2
+#          prefix: ""
 


### PR DESCRIPTION
Added a commented out `prefix` field to cr.yaml.  In our CR we have only S3 as an example, maybe we can add examples for other storages, Azure and GCS.

