### PR TITLE
Handle empty Orchestrator/Router

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -351,6 +351,10 @@ func (cr *PerconaServerMySQL) OrchestratorSpec() *OrchestratorSpec {
 	return &cr.Spec.Orchestrator
 }
 
+func (cr *PerconaServerMySQL) RouterSpec() *MySQLRouterSpec {
+	return cr.Spec.Router
+}
+
 func (cr *PerconaServerMySQL) CheckNSetDefaults(serverVersion *platform.ServerVersion) error {
 	if len(cr.Spec.MySQL.ClusterType) == 0 {
 		cr.Spec.MySQL.ClusterType = ClusterTypeAsync

--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -455,8 +455,8 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(serverVersion *platform.ServerVe
 		return errors.New("Orchestrator size must be 3 or greater and an odd number for raft setup")
 	}
 
-	if cr.Spec.MySQL.ClusterType == ClusterTypeGR && cr.Spec.Router == nil {
-		return errors.New("router section is needed for group replication")
+	if cr.Spec.MySQL.ClusterType == ClusterTypeAsync && cr.Spec.Orchestrator.Size == 0 {
+		return errors.Errorf("For clusterType %s orchestrator size must be set", ClusterTypeAsync)
 	}
 
 	if cr.Spec.Pause {


### PR DESCRIPTION
- Add information log about empty CR orchestrator/Router
(`CheckNSetDefaults()` raised an error)
- Disable setting the state to ready in case of empty size for any CR
when writing the appStatus (instead leave it in `initializing` state)
- Don't show router information in log in case of default async cluster

<details> <summary> No patch </summary> 
<pre>
2022-08-01T10:58:27.216Z        INFO    controller.perconaservermysql.reconcileUsers    MySQL is not ready      {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default"}
2022-08-01T10:58:27.217Z        INFO    controller.perconaservermysql.reconcileReplication      orchestrator is not ready. skip {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "ready": 0}
2022-08-01T10:58:27.224Z        DEBUG   controller.perconaservermysql.reconcileCRStatus Writing CR status       {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "mysql": {"size":3,"state":"initializing"}, "orchestrator": {"state":"ready"}, "router": {}, "host": "cluster1-mysql-primary.default", "state": "initializing"}
</pre>
</details>

<details> <summary> With patch </summary> 
<pre>

2022-08-01T12:02:28.031Z        INFO    controller.perconaservermysql.reconcileUsers    MySQL is not ready      {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default"}
2022-08-01T12:02:28.032Z        INFO    controller.perconaservermysql.reconcileOrchestrator     Orchestrator not specified.     {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default"}
2022-08-01T12:02:28.032Z        INFO    controller.perconaservermysql.reconcileReplication      orchestrator is not ready. skip {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "ready": 0}
2022-08-01T12:02:28.041Z        DEBUG   controller.perconaservermysql.reconcileCRStatus Writing CR status       {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "mysql": {"size":3,"state":"initializing"}, "orchestrator": {"state":"initializing"}, "host": "cluster1-mysql-primary.default", "state": "initializing"}

</pre>
</details>

- Tested with Orchestrator - didn't test with Router.
- `Image`: `anelh/percona-server-mysql-operator:cr-statuses-orch-router-info`