### PR TITLE
Add missing sts name for FQDN

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -79,7 +79,7 @@ func PodName(cr *apiv1alpha1.PerconaServerMySQL, idx int) string {
 
 func FQDN(cr *apiv1alpha1.PerconaServerMySQL, idx int) string {
 	// TODO: DNS suffix
-	return fmt.Sprintf("%s.%s.svc.cluster.local", PodName(cr, idx), cr.Namespace)
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", PodName(cr, idx), Name(cr), cr.Namespace)
 }
 
 func APIHost(cr *apiv1alpha1.PerconaServerMySQL) string {


### PR DESCRIPTION
One can see in the logs couple of errors where one of them seems to be wrong FQDN, missing service name
```bash
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
2022-07-28T09:46:49.859Z        DEBUG   controller.perconaservermysql.reconcileUsers    Secret data is up to date       {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default"}
2022-07-28T09:46:49.860Z        DEBUG   controller.perconaservermysql.reconcileReplicationPrimaryPod    got 3 pods      {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default"}
2022-07-28T09:46:49.862Z        DEBUG   controller.perconaservermysql.reconcileCRStatus Writing CR status       {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "mysql": {"size":3,"ready":3,"state":"ready"}, "orchestrator": {"size":3,"ready":2,"state":"initializing"}, "router": {}, "host": "cluster1-mysql-primary.default", "state": "initializing"}
2022-07-28T09:46:49.874Z        ERROR   controller.perconaservermysql   Reconciler error        {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "error": "reconcile: replication: reconcile primary pod: get cluster primary: do request to http://cluster1-orc-0.default.svc.cluster.local:3000/api/master/cluster1.default: do request: Get \"http://cluster1-orc-0.default.svc.cluster.local:3000/api/master/cluster1.default\": dial tcp 10.109.39.178:3000: connect: connection refused", "errorVerbose": "Get \"http://cluster1-orc-0.default.svc.cluster.local:3000/api/master/cluster1.default\": dial tcp 10.109.39.178:3000: connect: connection refused\ndo request\ngithub.com/percona/percona-server-mysql-operator/pkg/orchestrator.doRequest\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/orchestrator/client.go:175\ngithub.com/percona/percona-server-mysql-operator/pkg/orchestrator.ClusterPrimary\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/orchestrator/client.go:34\ngithub.com/percona/percona-server-mysql-operator/controllers.reconcileReplicationPrimaryPod\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:979\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:743\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:137\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:108\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\ndo request to http://cluster1-orc-0.default.svc.cluster.local:3000/api/master/cluster1.default\ngithub.com/percona/percona-server-mysql-operator/pkg/orchestrator.ClusterPrimary\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/orchestrator/client.go:36\ngithub.com/percona/percona-server-mysql-operator/controllers.reconcileReplicationPrimaryPod\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:979\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:743\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:137\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:108\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nget cluster primary\ngithub.com/percona/percona-server-mysql-operator/controllers.reconcileReplicationPrimaryPod\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:981\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:743\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:137\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:108\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreconcile primary pod\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:744\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:137\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:108\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreplication\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:138\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:108\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreconcile\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
```    
        
Solution
```
bash-4.4$ cat /etc/hosts
# Kubernetes-managed hosts file.
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
fe00::0 ip6-mcastprefix
fe00::1 ip6-allnodes
fe00::2 ip6-allrouters
172.17.0.4      cluster1-orc-0.cluster1-orc.default.svc.cluster.local   cluster1-orc-0

bash-4.4$ curl  http://cluster1-orc-0.cluster1-orc.default.svc.cluster.local:3000/api/master/cluster1.default
{"Key":{"Hostname":"cluster1-mysql-0.cluster1-mysql.default","Port":3306},"InstanceAlias":"cluster1-mysql-0","Uptime":806,"ServerID":14405730,"ServerUUID":"c1d0f241-0e3d-11ed-8e20-0242ac110005","Version":"8.0.28-19","VersionComment":"Percona Server (GPL), Release 19, Revision 31e88966cd3","FlavorName":"Percona","ReadOnly":false,"Binlog_format":"ROW","BinlogRowImage":"FULL","LogBinEnabled":true,"LogSlaveUpdatesEnabled":true,"LogReplicationUpdatesEnabled":true,"SelfBinlogCoordinates":{"LogFile":"binlog.000005","LogPos":5273,"Type":0},"MasterKey":{"Hostname":"","Port":0},"MasterUUID":"","AncestryUUID":"c1d0f241-0e3d-11ed-8e20-0242ac110005","IsDetachedMaster":false,"Slave_SQL_Running":false,"ReplicationSQLThreadRuning":false,"Slave_IO_Running":false,"ReplicationIOThreadRuning":false,"ReplicationSQLThreadState":-1,"ReplicationIOThreadState":-1,"HasReplicationFilters":false,"GTIDMode":"ON","SupportsOracleGTID":true,"UsingOracleGTID":false,"UsingMariaDBGTID":false,"UsingPseudoGTID":false,"ReadBinlogCoordinates":{"LogFile":"","LogPos":0,"Type":0},"ExecBinlogCoordinates":{"LogFile":"","LogPos":0,"Type":0},"IsDetached":false,"RelaylogCoordinates":{"LogFile":"","LogPos":0,"Type":1},"LastSQLError":"","LastIOError":"","SecondsBehindMaster":{"Int64":0,"Valid":false},"SQLDelay":0,"ExecutedGtidSet":"c1d0f241-0e3d-11ed-8e20-0242ac110005:1-54","GtidPurged":"","GtidErrant":"","SlaveLagSeconds":{"Int64":0,"Valid":false},"ReplicationLagSeconds":{"Int64":0,"Valid":false},"SlaveHosts":[{"Hostname":"cluster1-mysql-1.cluster1-mysql.default","Port":3306},{"Hostname":"cluster1-mysql-2.cluster1-mysql.default","Port":3306}],"Replicas":[{"Hostname":"cluster1-mysql-1.cluster1-mysql.default","Port":3306},{"Hostname":"cluster1-mysql-2.cluster1-mysql.default","Port":3306}],"ClusterName":"cluster1-mysql-0.cluster1-mysql.default:3306","SuggestedClusterAlias":"cluster1.default","DataCenter":"","Region":"","PhysicalEnvironment":"","ReplicationDepth":0,"IsCoMaster":false,"HasReplicationCredentials":false,"ReplicationCredentialsAvailable":false,"SemiSyncAvailable":true,"SemiSyncPriority":1,"SemiSyncMasterPluginNewVersion":false,"SemiSyncReplicaPluginNewVersion":false,"SemiSyncMasterEnabled":false,"SemiSyncReplicaEnabled":false,"SemiSyncMasterTimeout":10000,"SemiSyncMasterWaitForReplicaCount":1,"SemiSyncMasterStatus":false,"SemiSyncMasterClients":0,"SemiSyncReplicaStatus":false,"LastSeenTimestamp":"2022-07-28T09:54:37Z","IsLastCheckValid":true,"IsUpToDate":true,"IsRecentlyChecked":true,"SecondsSinceLastSeen":{"Int64":3,"Valid":true},"CountMySQLSnapshots":0,"IsCandidate":false,"PromotionRule":"neutral","IsDowntimed":false,"DowntimeReason":"","DowntimeOwner":"","DowntimeEndTimestamp":"","ElapsedDowntime":0,"UnresolvedHostname":"","AllowTLS":false,"Problems":[],"LastDiscoveryLatency":5827165,"ReplicationGroupName":"","ReplicationGroupIsSinglePrimary":false,"ReplicationGroupMemberState":"","ReplicationGroupMemberRole":"","ReplicationGroupMembers":[],"ReplicationGroupPrimaryInstanceKey":{"Hostname":"","Port":0}}bash-4.4$ curl  http://cluster1-orc-0.cluster1-orc.bash-4.4$ cat /etc/hosts
```