### PR TITLE
Add check for empty alias

### DIFF
--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -22,10 +22,11 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -1314,7 +1315,7 @@ func getPrimaryFromOrchestrator(ctx context.Context, cr *apiv1alpha1.PerconaServ
 		return nil, errors.Wrap(err, "get cluster primary")
 	}
 
-	if primary.Key.Hostname == "" {
+	if primary.Key.Hostname == "" && primary.Alias != "" {
 		primary.Key.Hostname = fmt.Sprintf("%s.%s.%s", primary.Alias, mysql.ServiceName(cr), cr.Namespace)
 	}
 


### PR DESCRIPTION
Error message raised when new replica occurs with hostname created from `primary.Key.Hostname` based on service name and Namespace -> `.cluster1-mysql.default`, however alias doesn't exist:
```bash
2022-08-01T14:22:09.423Z        ERROR   controller.perconaservermysql   Reconciler error        {"reconciler group": "ps.percona.com", "reconciler kind": "PerconaServerMySQL", "name": "cluster1", "namespace": "default", "error": "reconcile: replication: reconcile semi-sync: connect to .cluster1-mysql.default: ping database: dial tcp: lookup .cluster1-mysql.default: no such host", "errorVerbose": "dial tcp: lookup .cluster1-mysql.default: no such host\nping database\ngithub.com/percona/percona-server-mysql-operator/pkg/replicator.NewReplicator\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/replicator/replicator.go:73\ngithub.com/percona/percona-server-mysql-operator/controllers.reconcileReplicationSemiSync\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:1046\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:747\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:138\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nconnect to .cluster1-mysql.default\ngithub.com/percona/percona-server-mysql-operator/controllers.reconcileReplicationSemiSync\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:1051\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:747\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:138\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreconcile semi-sync\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).reconcileReplication\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:748\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:138\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreplication\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:139\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571\nreconcile\ngithub.com/percona/percona-server-mysql-operator/controllers.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/controllers/perconaservermysql_controller.go:110\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/src/github.com/percona/percona-server-mysql-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
```
Missing some testing.
Variables (with and without previous patch for FQDN PR #129) obtained using custom logs:
```yaml
"URL": "http://cluster1-orc-0.cluster1-orc.default.svc.cluster.local:3000/api/master/cluster1.default"}
"respError": "json: unsupported type: func() (io.ReadCloser, error)"} <- response error in cluster primary
"body": "eyJDb2RlIjoiRVJST1IiLCJNZXNzYWdlIjoiMjAyMi0wOC0wMSAxNDoyMjowOSBFUlJPUiBVbmFibGUgdG8gZGV0ZXJtaW5lIGNsdXN0ZXIgbmFtZS4gY2x1c3RlckhpbnQ9Y2x1c3RlcjEuZGVmYXVsdCIsIkRldGFpbHMiOm51bGx9"}
"primary": {"Key":{"Hostname":"","Port":0},"InstanceAlias":"","MasterKey":{"Hostname":"","Port":0},"Replicas":null}}
```
Commit introduced the change: 1bc83079