### PR TITLE
K8SPS-152 - Add expose option for orchestrator in cr.yaml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ void runTest(String TEST_NAME, String CLUSTER_SUFFIX) {
             echo "The $TEST_NAME test was started!"
             testsReportMap[TEST_NAME] = "[failed]($testUrl)"
 
-            FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME-gke-${env.PLATFORM_VER}"
+            def FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME"
             popArtifactFile("$FILE_NAME")
 
             timeout(time: 90, unit: 'MINUTES') {
@@ -114,7 +114,7 @@ void runTest(String TEST_NAME, String CLUSTER_SUFFIX) {
             }
             pushArtifactFile("$FILE_NAME")
             testsReportMap[TEST_NAME] = "[passed]($testUrl)"
-            testsResultsMap["${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME"] = 'passed'
+            testsResultsMap["$FILE_NAME"] = 'passed'
             return true
         }
         catch (exc) {

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -123,8 +123,8 @@ spec:
 #                - e2e-az1
 #                - e2e-az2
 
-    expose:
-      type: ClusterIP
+#    expose:
+#      type: ClusterIP
 
     resources:
       requests:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -123,6 +123,9 @@ spec:
 #                - e2e-az1
 #                - e2e-az2
 
+    expose:
+      type: ClusterIP
+
     resources:
       requests:
         memory: 128M


### PR DESCRIPTION
[![K8SPS-152](https://badgen.net/badge/JIRA/K8SPS-152/green)](https://jira.percona.com/browse/K8SPS-152) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

ClusterIP is used by default, but option is needed if you want to set it to LoadBalancer