### PR TITLE
K8SPS-17: use `pt-heartbeat` only with async clusterType

### DIFF
--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -452,7 +452,7 @@ func containers(cr *apiv1alpha1.PerconaServerMySQL, secret *corev1.Secret) []cor
 		containers = append(containers, backupContainer(cr))
 	}
 
-	if toolkit := cr.Spec.Toolkit; toolkit != nil {
+	if toolkit := cr.Spec.Toolkit; toolkit != nil && cr.Spec.MySQL.IsAsync() {
 		containers = append(containers, heartbeatContainer(cr))
 	}
 


### PR DESCRIPTION
[![K8SPS-17](https://badgen.net/badge/JIRA/K8SPS-17/green)](https://jira.percona.com/browse/K8SPS-17) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPS-17