### PR TITLE
K8SPS-63: Using default version when failing to get them from VS

### DIFF
--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -297,7 +297,8 @@ func (r *PerconaServerMySQLReconciler) reconcileVersions(ctx context.Context, cr
 
 	version, err := vs.GetVersion(ctx, cr, r.ServerVersion)
 	if err != nil {
-		return errors.Wrap(err, "get exact version")
+		l.Info("Failed to get versions, using the default ones", "error", err)
+		return nil
 	}
 
 	patch := client.MergeFrom(cr.DeepCopy())
@@ -344,7 +345,8 @@ func (r *PerconaServerMySQLReconciler) reconcileVersions(ctx context.Context, cr
 
 	err = r.Patch(ctx, cr.DeepCopy(), patch)
 	if err != nil {
-		return errors.Wrap(err, "failed to update CR")
+		l.Info("Failed to update CR, using the default version", "error", err)
+		return nil
 	}
 
 	cr.Status.MySQL.Version = version.PSVersion


### PR DESCRIPTION
[![K8SPS-63](https://badgen.net/badge/JIRA/K8SPS-63/green)](https://jira.percona.com/browse/K8SPS-63) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Like we have it in PXC, if we fail to get versions from VS, we should continue with default ones. 
Here is the logic in PXC: https://github.com/percona/percona-xtradb-cluster-operator/blob/main/pkg/controller/pxc/controller.go#L304