### PR TITLE
K8SPS-180: remove unnecessary stacktrace in `delete-mysql-pods-in-order` finalizer

### DIFF
--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -136,7 +136,12 @@ func (r *PerconaServerMySQLReconciler) applyFinalizers(ctx context.Context, cr *
 		}
 
 		if err != nil {
-			l.Error(err, "failed to run finalizer", "finalizer", f)
+			switch err {
+			case ErrWaitingTermination:
+				l.Info("waiting for pods to be deleted", "finalizer", f)
+			default:
+				l.Error(err, "failed to run finalizer", "finalizer", f)
+			}
 			finalizers = append(finalizers, f)
 		}
 	}
@@ -247,7 +252,7 @@ func (r *PerconaServerMySQLReconciler) deleteMySQLPods(ctx context.Context, cr *
 		l.Info("sts replicaset downscaled", "sts", sts)
 	}
 
-	return errors.New("waiting for pods to be deleted")
+	return ErrWaitingTermination
 }
 
 func (r *PerconaServerMySQLReconciler) doReconcile(


### PR DESCRIPTION
[![K8SPS-180](https://badgen.net/badge/JIRA/K8SPS-180/green)](https://jira.percona.com/browse/K8SPS-180) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPS-180