### PR TITLE
K8SPS-175: fix `delete-backup` finalizer

### DIFF
--- a/controllers/perconaservermysqlbackup_controller.go
+++ b/controllers/perconaservermysqlbackup_controller.go
@@ -377,8 +377,9 @@ func (r *PerconaServerMySQLBackupReconciler) backupConfig(ctx context.Context, c
 	if storage.VerifyTLS != nil {
 		verifyTLS = *storage.VerifyTLS
 	}
+	destination := getDestination(storage, cr.Spec.ClusterName, cr.CreationTimestamp.Format("2006-01-02-15:04:05"))
 	conf := &xtrabackup.BackupConfig{
-		Destination: cr.Status.Destination,
+		Destination: destination,
 		VerifyTLS:   verifyTLS,
 	}
 	s := new(corev1.Secret)


### PR DESCRIPTION
[![K8SPS-175](https://badgen.net/badge/JIRA/K8SPS-175/green)](https://jira.percona.com/browse/K8SPS-175) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPS-175

This PR changes the backup destination provided to `xbcloud` in the `delete-backup` finalizer. Previously we provided destination from backup status with `gs://`- like prefixes and bucket/container names. We should strip prefixes and bucket/container names because:
1. `xbcloud` doesn't support the `gs://` prefix: https://github.com/percona/percona-xtrabackup/blob/a19fe35f768256a81cad3f2f421f9049b70f1bb0/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc#L632-L649
2. we already provide bucket/container names in the `xbCloudArgs` function