### PR TITLE
Fix group-replication cluster creation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -58,8 +58,7 @@ RUN export GNUPGHOME="$(mktemp -d)" \
 
 RUN set -ex; \
     microdnf update; \
-    microdnf install -y glibc-langpack-en; \
-    microdnf install -y percona-mysql-shell; \
+    microdnf install -y glibc-langpack-en percona-mysql-shell; \
     microdnf clean all; \
     rm -rf /var/cache; \
     rm -rf /usr/lib/debug/usr/bin;

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,47 +17,48 @@ COPY . .
 RUN mkdir -p build/_output/bin \
     && GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
-        -o build/_output/bin/percona-server-mysql-operator \
-            cmd/manager/main.go \
+    -o build/_output/bin/percona-server-mysql-operator \
+    cmd/manager/main.go \
     && cp -r build/_output/bin/percona-server-mysql-operator /usr/local/bin/percona-server-mysql-operator
 RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
-        -o build/_output/bin/bootstrap \
-            cmd/bootstrap/main.go \
+    -o build/_output/bin/bootstrap \
+    cmd/bootstrap/main.go \
     && cp -r build/_output/bin/bootstrap /usr/local/bin/bootstrap
 RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
-        -o build/_output/bin/healthcheck \
-            cmd/healthcheck/main.go \
+    -o build/_output/bin/healthcheck \
+    cmd/healthcheck/main.go \
     && cp -r build/_output/bin/healthcheck /usr/local/bin/healthcheck
 RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
-        -o build/_output/bin/sidecar \
-            cmd/sidecar/main.go \
+    -o build/_output/bin/sidecar \
+    cmd/sidecar/main.go \
     && cp -r build/_output/bin/sidecar /usr/local/bin/sidecar
 RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
-        -o build/_output/bin/peer-list \
-            cmd/peer-list/main.go \
+    -o build/_output/bin/peer-list \
+    cmd/peer-list/main.go \
     && cp -r build/_output/bin/peer-list /usr/local/bin/peer-list
 
 FROM redhat/ubi8-minimal AS ubi8
 
 # check repository package signature in secure way
 RUN export GNUPGHOME="$(mktemp -d)" \
-        && microdnf install -y findutils \
-        && gpg --keyserver keyserver.ubuntu.com --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-        && gpg --export --armor 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A > ${GNUPGHOME}/RPM-GPG-KEY-Percona \
-        && rpmkeys --import ${GNUPGHOME}/RPM-GPG-KEY-Percona \
-        && curl -Lf -o /tmp/percona-release.rpm https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
-        && rpmkeys --checksig /tmp/percona-release.rpm \
-        && rpm -i /tmp/percona-release.rpm \
-        && rm -rf "$GNUPGHOME" /tmp/percona-release.rpm \
-        && rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY \
-        && percona-release setup pdps-8.0
+    && microdnf install -y findutils \
+    && gpg --keyserver keyserver.ubuntu.com --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+    && gpg --export --armor 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A > ${GNUPGHOME}/RPM-GPG-KEY-Percona \
+    && rpmkeys --import ${GNUPGHOME}/RPM-GPG-KEY-Percona \
+    && curl -Lf -o /tmp/percona-release.rpm https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
+    && rpmkeys --checksig /tmp/percona-release.rpm \
+    && rpm -i /tmp/percona-release.rpm \
+    && rm -rf "$GNUPGHOME" /tmp/percona-release.rpm \
+    && rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY \
+    && percona-release setup pdps-8.0
 
 RUN set -ex; \
     microdnf update; \
+    microdnf install -y glibc-langpack-en; \
     microdnf install -y percona-mysql-shell; \
     microdnf clean all; \
     rm -rf /var/cache; \
@@ -67,10 +68,10 @@ RUN mkdir /sbin/.mysqlsh && chown 2:2 /sbin/.mysqlsh
 RUN mkdir /opt/percona-server-mysql-operator
 
 LABEL name="Percona Distribution for MySQL Operator" \
-      vendor="Percona" \
-      summary="Percona Distribution for MySQL Operator v1alpha1 contains everything you need to quickly and consistently deploy and scale Percona Server for MySQL instances" \
-      description="Percona Distribution for MySQL Operator v1alpha1 contains everything you need to quickly and consistently deploy and scale Percona Server for MySQL instances in a Kubernetes-based environment, both on-premises or in the cloud" \
-      maintainer="Percona Development <info@percona.com>"
+    vendor="Percona" \
+    summary="Percona Distribution for MySQL Operator v1alpha1 contains everything you need to quickly and consistently deploy and scale Percona Server for MySQL instances" \
+    description="Percona Distribution for MySQL Operator v1alpha1 contains everything you need to quickly and consistently deploy and scale Percona Server for MySQL instances in a Kubernetes-based environment, both on-premises or in the cloud" \
+    maintainer="Percona Development <info@percona.com>"
 
 COPY LICENSE /licenses/
 COPY --from=go_builder /usr/local/bin/percona-server-mysql-operator /usr/local/bin/percona-server-mysql-operator

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -1120,7 +1120,7 @@ func (r *PerconaServerMySQLReconciler) reconcileGroupReplication(ctx context.Con
 
 	if !clusterExists {
 		l.Info("Creating InnoDB cluster")
-		err := mysh.CreateCluster(ctx, cr.InnoDBClusterName(), firstPod.Status.PodIP)
+		err := mysh.CreateCluster(ctx, cr.InnoDBClusterName())
 		if err != nil {
 			return errors.Wrapf(err, "create cluster %s", cr.InnoDBClusterName())
 		}
@@ -1191,7 +1191,7 @@ func (r *PerconaServerMySQLReconciler) reconcileGroupReplication(ctx context.Con
 			}
 			l.Info("Configured instance", "pod", pod.Name)
 
-			if err := mysh.AddInstance(ctx, cr.InnoDBClusterName(), podUri, pod.Status.PodIP); err != nil {
+			if err := mysh.AddInstance(ctx, cr.InnoDBClusterName(), podUri); err != nil {
 				return errors.Wrapf(err, "add instance %s", pod.Name)
 			}
 			l.Info("Added instance to the cluster", "cluster", cr.Name, "pod", pod.Name)

--- a/pkg/mysqlsh/mysqlsh.go
+++ b/pkg/mysqlsh/mysqlsh.go
@@ -24,8 +24,6 @@ var ErrMetadataExistsButGRNotActive = errors.New("MYSQLSH 51314: metadata exists
 
 var sensitiveRegexp = regexp.MustCompile(":.*@")
 
-const defaultIPAllowList = "127.0.0.1/8,::1/128"
-
 func New(e k8sexec.Interface, uri string) *mysqlsh {
 	return &mysqlsh{exec: e, uri: uri}
 }
@@ -61,17 +59,15 @@ func (m *mysqlsh) ConfigureInstance(ctx context.Context, instance string) error 
 	return nil
 }
 
-func (m *mysqlsh) AddInstance(ctx context.Context, clusterName, instance, podIp string) error {
+func (m *mysqlsh) AddInstance(ctx context.Context, clusterName, instance string) error {
 	opts := struct {
 		Interactive    bool   `json:"interactive"`
 		RecoveryMethod string `json:"recoveryMethod"`
 		WaitRecovery   int    `json:"waitRecovery"`
-		IpAllowList    string `json:"ipAllowList"`
 	}{
 		Interactive:    false,
 		RecoveryMethod: "clone",
 		WaitRecovery:   0,
-		IpAllowList:    fmt.Sprintf("%s,%s/8", defaultIPAllowList, podIp),
 	}
 
 	o, err := json.Marshal(opts)
@@ -108,8 +104,8 @@ func (m *mysqlsh) RemoveInstance(ctx context.Context, clusterName, instance stri
 	return nil
 }
 
-func (m *mysqlsh) CreateCluster(ctx context.Context, clusterName, podIp string) error {
-	cmd := fmt.Sprintf("dba.createCluster('%s', {'ipAllowList': '%s,%s/8'})", clusterName, defaultIPAllowList, podIp)
+func (m *mysqlsh) CreateCluster(ctx context.Context, clusterName string) error {
+	cmd := fmt.Sprintf("dba.createCluster('%s')", clusterName)
 
 	if err := m.run(ctx, cmd); err != nil {
 		return errors.Wrap(err, "create cluster")


### PR DESCRIPTION
In MySQL Shell 8.0.30 `communicationStack` option was added. By default, it uses the `MYSQL` communication stack value, which doesn't allow us to use the `ipAllowList` option.

As mentioned here: https://dev.mysql.com/doc/relnotes/mysql-shell/8.0/en/news-8-0-30.html, the `MYSQL` communication stack obsoletes the usage of IP allowlists. So, they should be removed.

Also, fixes the `mysqlsh` warning `Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory` by installing `glibc-langpack-en`