### PR TITLE
K8SPS-181 decrease the value for innodb_buffer_pool_size option

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -26,7 +26,7 @@ spec:
 #  initImage: perconalab/percona-server-mysql-operator:main
 
   mysql:
-    clusterType: async
+    clusterType: group-replication
     image: perconalab/percona-server-mysql-operator:main-psmysql
     imagePullPolicy: Always
 #    initImage: perconalab/percona-server-mysql-operator:main

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -114,6 +114,7 @@ get_cr() {
 		| yq eval '.spec.secretsName="test-secrets"' - \
 		| yq eval '.spec.sslSecretName="test-ssl"' - \
 		| yq eval '.spec.upgradeOptions.apply="disabled"' - \
+		| yq eval '.spec.mysql.clusterType="async"' - \
 		| yq eval "$(printf '.spec.mysql.image="%s"' "${IMAGE_MYSQL}")" - \
 		| yq eval "$(printf '.spec.backup.image="%s"' "${IMAGE_BACKUP}")" - \
 		| yq eval "$(printf '.spec.orchestrator.image="%s"' "${IMAGE_ORCHESTRATOR}")" - \
@@ -334,16 +335,9 @@ check_auto_tuning() {
 			exit 1
 		fi
 	else
-		if [[ 1000000000 -lt $((RAM_SIZE - $((RAM_SIZE * 75 / 100)))) ]]; then
-			if [[ ${INNODB_SIZE} != $((RAM_SIZE * 75 / 100)) ]]; then
-				echo "innodb_buffer_pool_size is set to ${INNODB_SIZE}, which does not correlate with cr.pxc.limits.memory * 0.75"
-				exit 1
-			fi
-		else
-			if [[ ${INNODB_SIZE} != $((RAM_SIZE * 50 / 100)) ]]; then
-				echo "innodb_buffer_pool_size is set to ${INNODB_SIZE}, which does not correlate with cr.pxc.limits.memory * 0.5"
-				exit 1
-			fi
+		if [[ ${INNODB_SIZE} != $((RAM_SIZE * 50 / 100)) ]]; then
+			echo "innodb_buffer_pool_size is set to ${INNODB_SIZE}, which does not correlate with cr.pxc.limits.memory * 0.5"
+			exit 1
 		fi
 	fi
 

--- a/pkg/mysql/config.go
+++ b/pkg/mysql/config.go
@@ -14,10 +14,7 @@ import (
 func GetAutoTuneParams(cr *apiv1alpha1.PerconaServerMySQL, q *resource.Quantity) (string, error) {
 	autotuneParams := ""
 
-	poolSize := q.Value() * int64(75) / int64(100)
-	if q.Value()-poolSize < int64(1000000000) {
-		poolSize = q.Value() * int64(50) / int64(100)
-	}
+	poolSize  := q.Value() * int64(50) / int64(100)
 	instances := int64(1)                 // default value
 	chunkSize := int64(1024 * 1024 * 128) // default value
 

--- a/pkg/mysql/config.go
+++ b/pkg/mysql/config.go
@@ -14,7 +14,7 @@ import (
 func GetAutoTuneParams(cr *apiv1alpha1.PerconaServerMySQL, q *resource.Quantity) (string, error) {
 	autotuneParams := ""
 
-	poolSize  := q.Value() * int64(50) / int64(100)
+	poolSize := q.Value() * int64(50) / int64(100)
 	instances := int64(1)                 // default value
 	chunkSize := int64(1024 * 1024 * 128) // default value
 


### PR DESCRIPTION
[![K8SPS-181](https://badgen.net/badge/JIRA/K8SPS-181/green)](https://jira.percona.com/browse/K8SPS-181) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* 75% of RAM it is big value for innodb_buffer_pool_size
      in order to avoid OOMKilled we need to use max 50%    
 * set group-replication as a default type in CR