### PR TITLE
K8SPS-78 Freeze kuttl version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,8 @@ void prepareNode() {
         ./"${KREW}" install krew
         rm -f "${KREW}.tar.gz"
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-        kubectl krew install kuttl
+        # v0.14.0 kuttl version
+        kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/7a3144dc1553407d47583b5d240a115345117819/plugins/kuttl.yaml
     '''
 }
 


### PR DESCRIPTION
[![K8SPS-78](https://badgen.net/badge/JIRA/K8SPS-78/green)](https://jira.percona.com/browse/K8SPS-78) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Recent events made clear the neccessity of keeping kuttl version fixed in time and space. Krew does not support versioning, thus installing kuttl from github sourced manifest.