### PR TITLE
K8SPS-78 Kuttl 0.15.0 compatibility update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,6 +202,7 @@ void prepareNode() {
         ./"${KREW}" install krew
         rm -f "${KREW}.tar.gz"
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+        printf "Kuttl %s is to be installed" "$(curl -s https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/plugins/kuttl.yaml | yq eval '.spec.version' -)"
         kubectl krew install kuttl
     '''
 }

--- a/e2e-tests/kuttl.yaml
+++ b/e2e-tests/kuttl.yaml
@@ -2,3 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - e2e-tests/tests
+timeout: 180

--- a/e2e-tests/tests/auto-config/12-drop-finalizer
+++ b/e2e-tests/tests/auto-config/12-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: auto-config
+  finalizers: []

--- a/e2e-tests/tests/config/09-drop-finalizer
+++ b/e2e-tests/tests/config/09-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: config
+  finalizers: []

--- a/e2e-tests/tests/demand-backup/23-drop-finalizer
+++ b/e2e-tests/tests/demand-backup/23-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: demand-backup
+  finalizers: []

--- a/e2e-tests/tests/gr-demand-backup/19-drop-finalizer
+++ b/e2e-tests/tests/gr-demand-backup/19-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-demand-backup
+  finalizers: []

--- a/e2e-tests/tests/gr-init-deploy/06-drop-finalizer
+++ b/e2e-tests/tests/gr-init-deploy/06-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-init-deploy
+  finalizers: []

--- a/e2e-tests/tests/haproxy/10-drop-finalizer
+++ b/e2e-tests/tests/haproxy/10-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: haproxy
+  finalizers: []

--- a/e2e-tests/tests/init-deploy/06-drop-finalizer
+++ b/e2e-tests/tests/init-deploy/06-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: init-deploy
+  finalizers: []

--- a/e2e-tests/tests/limits/08-drop-finalizer
+++ b/e2e-tests/tests/limits/08-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: limits-no-storage
+  finalizers: []

--- a/e2e-tests/tests/monitoring/04-drop-finalizer
+++ b/e2e-tests/tests/monitoring/04-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: monitoring
+  finalizers: []

--- a/e2e-tests/tests/one-pod/07-drop-finalizer
+++ b/e2e-tests/tests/one-pod/07-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: one-pod
+  finalizers: []

--- a/e2e-tests/tests/scaling/09-drop-finalizer
+++ b/e2e-tests/tests/scaling/09-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: scaling
+  finalizers: []

--- a/e2e-tests/tests/semi-sync/05-drop-finalizer
+++ b/e2e-tests/tests/semi-sync/05-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: semi-sync
+  finalizers: []

--- a/e2e-tests/tests/service-per-pod/06-drop-finalizer
+++ b/e2e-tests/tests/service-per-pod/06-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: service-per-pod
+  finalizers: []

--- a/e2e-tests/tests/sidecars/02-drop-finalizer
+++ b/e2e-tests/tests/sidecars/02-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: sidecars
+  finalizers: []

--- a/e2e-tests/tests/tls-cert-manager/03-drop-finalizer
+++ b/e2e-tests/tests/tls-cert-manager/03-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: tls-cert-manager
+  finalizers: []

--- a/e2e-tests/tests/users/05-drop-finalizer
+++ b/e2e-tests/tests/users/05-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: users
+  finalizers: []

--- a/e2e-tests/tests/version-service/08-drop-finalizer
+++ b/e2e-tests/tests/version-service/08-drop-finalizer
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: cluster-exact
+  finalizers: []


### PR DESCRIPTION
[![K8SPS-78](https://badgen.net/badge/JIRA/K8SPS-78/green)](https://jira.percona.com/browse/K8SPS-78) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The latest version of kuttls waits for namespace removal. In our case would have waited forever of fail on timeout since the finalizer restricts k8s from cluster object removal. Additing finalizers wipeout then.

A few words about timeout on TestSuite level. The default timeout for namespace deletion in not long enough for us. Since it's not managed by any TestStep this is the only way how we can ask kuttl to wait a bit longer.