### PR TITLE
CLOUD-756 - Fix pipeline to delete/post GH results only if no new build initiated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -420,7 +420,7 @@ pipeline {
         always {
             script {
                 setTestsresults()
-                if (currentBuild.result != null && currentBuild.result != 'SUCCESS' && currentBuild.result != 'NOT_BUILT') {
+                if (currentBuild.result != null && currentBuild.result != 'SUCCESS' && currentBuild.nextBuild == null) {
                     try {
                         slackSend channel: "@${AUTHOR_NAME}", color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                     }
@@ -428,7 +428,7 @@ pipeline {
                         slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                     }
                 }
-                if (env.CHANGE_URL) {
+                if (env.CHANGE_URL && currentBuild.nextBuild == null) {
                     for (comment in pullRequest.comments) {
                         println("Author: ${comment.user}, Comment: ${comment.body}")
                         if (comment.user.equals('JNKPercona')) {
@@ -436,13 +436,11 @@ pipeline {
                             comment.delete()
                         }
                     }
-                    if (currentBuild.result != 'NOT_BUILT') {
-                        makeReport()
-                        unstash 'IMAGE'
-                        def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
-                        TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: `${IMAGE}`\r\n"
-                        pullRequest.comment(TestsReport)
-                    }
+                    makeReport()
+                    unstash 'IMAGE'
+                    def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
+                    TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: `${IMAGE}`\r\n"
+                    pullRequest.comment(TestsReport)
                 }
             }
             DeleteOldClusters("$CLUSTER_NAME")


### PR DESCRIPTION
[![CLOUD-756](https://badgen.net/badge/JIRA/CLOUD-756/green)](https://jira.percona.com/browse/CLOUD-756) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Problem:
Old build can delete github results from the build which was initiated later in the pipeline.

Cause:
If for eg. build nr. 28 is aborted/superseeded with build 29, but jenkins doesn't fully kill the pipeline until it times out it can happen that build br. 29 finishes first and posts results, then nr. 28 finally times out and deletes the github results from the build 29 for which we actually care.

Solution:
If current build is not the latest do not delete the github results and do not post new results - we just don't care about this build results since we already know there is a newer one.