### PR TITLE
CLOUD-765 - Fix printing of installed kuttl version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,8 +202,8 @@ void prepareNode() {
         ./"${KREW}" install krew
         rm -f "${KREW}.tar.gz"
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-        printf "Kuttl %s is to be installed" "$(curl -s https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/plugins/kuttl.yaml | yq eval '.spec.version' -)"
         kubectl krew install kuttl
+        printf "%s is installed" "$(kubectl kuttl --version)"
     '''
 }
 


### PR DESCRIPTION
[![CLOUD-765](https://badgen.net/badge/JIRA/CLOUD-765/green)](https://jira.percona.com/browse/CLOUD-765) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*We print version from github repo and not the version which is installed (it can be different).*

**Solution:**
*Just install the kuttl and print installed version.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?