### PR TITLE
K8SPS-236: Remove formatted strings from log messages.

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -416,7 +416,7 @@ func (cr *PerconaServerMySQL) SetVersion() {
 }
 
 func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersion *platform.ServerVersion) error {
-	l := log.FromContext(ctx).WithName("CheckNSetDefaults")
+	log := log.FromContext(ctx).WithName("CheckNSetDefaults")
 	if len(cr.Spec.MySQL.ClusterType) == 0 {
 		cr.Spec.MySQL.ClusterType = ClusterTypeAsync
 	}
@@ -559,7 +559,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersi
 			}
 		default:
 			cr.Spec.Orchestrator.Enabled = true
-			l.Info("orchestrator can't be disabled on an existing cluster")
+			log.Info("orchestrator can't be disabled on an existing cluster")
 		}
 	}
 

--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -33,7 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -416,7 +416,7 @@ func (cr *PerconaServerMySQL) SetVersion() {
 }
 
 func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersion *platform.ServerVersion) error {
-	log := log.FromContext(ctx).WithName("CheckNSetDefaults")
+	log := logf.FromContext(ctx).WithName("CheckNSetDefaults")
 	if len(cr.Spec.MySQL.ClusterType) == 0 {
 		cr.Spec.MySQL.ClusterType = ClusterTypeAsync
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -170,7 +170,7 @@ func getLogEncoder(log logr.Logger) zapcore.Encoder {
 
 	useJson, err := strconv.ParseBool(s)
 	if err != nil {
-		log.Info(fmt.Sprintf("can't parse LOG_STRUCTURED env var: %s, using console logger", s))
+		log.Info("Can't parse LOG_STRUCTURED env var, using console logger", "envVar", s)
 		return consoleEnc
 	}
 	if !useJson {
@@ -194,7 +194,7 @@ func getLogLevel(log logr.Logger) zapcore.LevelEnabler {
 	case "ERROR":
 		return zapcore.ErrorLevel
 	default:
-		log.Info(fmt.Sprintf("unsupported log level: %s, using INFO level", l))
+		log.Info("Unsupported log level, using INFO", "level", l)
 		return zapcore.InfoLevel
 	}
 }

--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -124,7 +124,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 				return errors.Wrapf(err, "remove label from old primary pod: %v/%v", pod.GetNamespace(), pod.GetName())
 			}
 
-			log.Info("Removed lavel from of old primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
+			log.Info("Removed label from the old primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 		}
 	}
 

--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -125,7 +125,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 				return errors.Wrapf(err, "remove label from old primary pod: %v/%v", pod.GetNamespace(), pod.GetName())
 			}
 
-			l.Info(fmt.Sprintf("removed label from old primary pod: %v/%v", pod.GetNamespace(), pod.GetName()))
+			l.Info("Removed lavel from of old primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 		}
 	}
 
@@ -134,7 +134,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 	}
 
 	if primaryPod.GetLabels()[apiv1alpha1.MySQLPrimaryLabel] == "true" {
-		l.Info(fmt.Sprintf("primary %v is not changed. skip", primaryName))
+		l.Info("Primary pod not changed, skipping", "pod", primaryName)
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 		return errors.Wrapf(err, "add label to new primary pod %v/%v", pod.GetNamespace(), pod.GetName())
 	}
 
-	l.Info(fmt.Sprintf("added label to new primary pod: %v/%v", pod.GetNamespace(), pod.GetName()))
+	l.Info("Labels added to the new primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 	return nil
 }
 

--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -72,7 +72,7 @@ func getClusterName() (string, error) {
 }
 
 func setPrimaryLabel(ctx context.Context, primary string) error {
-	l := log.WithName("setPrimaryLabel")
+	log := log.WithName("setPrimaryLabel")
 
 	ns, err := getNamespace()
 	if err != nil {
@@ -125,7 +125,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 				return errors.Wrapf(err, "remove label from old primary pod: %v/%v", pod.GetNamespace(), pod.GetName())
 			}
 
-			l.Info("Removed lavel from of old primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
+			log.Info("Removed lavel from of old primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 		}
 	}
 
@@ -134,7 +134,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 	}
 
 	if primaryPod.GetLabels()[apiv1alpha1.MySQLPrimaryLabel] == "true" {
-		l.Info("Primary pod not changed, skipping", "pod", primaryName)
+		log.Info("Primary pod not changed, skipping", "pod", primaryName)
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 		return errors.Wrapf(err, "add label to new primary pod %v/%v", pod.GetNamespace(), pod.GetName())
 	}
 
-	l.Info("Labels added to the new primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
+	log.Info("Labels added to the new primary pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 	return nil
 }
 

--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -133,7 +133,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 	}
 
 	if primaryPod.GetLabels()[apiv1alpha1.MySQLPrimaryLabel] == "true" {
-		log.Info("Primary pod not changed, skipping", "pod", primaryName)
+		log.Info("Primary pod is not changed, skipping", "pod", primaryName)
 		return nil
 	}
 

--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"os/signal"
 	"strings"

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -676,7 +676,7 @@ func (r *PerconaServerMySQLReconciler) reconcileDatabase(
 
 	if pmm := cr.Spec.PMM; pmm != nil && pmm.Enabled && !pmm.HasSecret(internalSecret) {
 		log.Info(fmt.Sprintf(`Can't enable PMM: either "%s" key doesn't exist in the secrets, or secrets and internal secrets are out of sync`,
-		apiv1alpha1.UserPMMServerKey), "secrets", cr.Spec.SecretsName, "internalSecrets", cr.InternalSecretName())
+			apiv1alpha1.UserPMMServerKey), "secrets", cr.Spec.SecretsName, "internalSecrets", cr.InternalSecretName())
 	}
 
 	return nil

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -675,8 +675,7 @@ func (r *PerconaServerMySQLReconciler) reconcileDatabase(
 	}
 
 	if pmm := cr.Spec.PMM; pmm != nil && pmm.Enabled && !pmm.HasSecret(internalSecret) {
-		l.Info("Can't enable PMM, either key doesn't exist or secrets and internal secrets are our of sync", "key",
-			apiv1alpha1.UserPMMServerKey, "secrets", cr.Spec.SecretsName, "internalSecrets", cr.InternalSecretName())
+		l.Info("Can't enable PMM, credentials are not setup correctly or secrets and internal secrets are our of sync")
 	}
 
 	return nil

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -43,7 +43,7 @@ import (
 	k8sexec "k8s.io/utils/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
 	"github.com/percona/percona-server-mysql-operator/pkg/haproxy"
@@ -93,7 +93,7 @@ func (r *PerconaServerMySQLReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
-	log := log.FromContext(ctx).WithName("PerconaServerMySQL")
+	log := logf.FromContext(ctx).WithName("PerconaServerMySQL")
 
 	rr := ctrl.Result{RequeueAfter: 5 * time.Second}
 
@@ -125,7 +125,7 @@ func (r *PerconaServerMySQLReconciler) Reconcile(
 }
 
 func (r *PerconaServerMySQLReconciler) applyFinalizers(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("Finalizer")
+	log := logf.FromContext(ctx).WithName("Finalizer")
 	log.Info("Applying finalizers", "CR", cr)
 
 	var err error
@@ -160,7 +160,7 @@ func (r *PerconaServerMySQLReconciler) applyFinalizers(ctx context.Context, cr *
 }
 
 func (r *PerconaServerMySQLReconciler) deleteMySQLPods(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr))
 	if err != nil {
@@ -304,7 +304,7 @@ func (r *PerconaServerMySQLReconciler) reconcileVersions(ctx context.Context, cr
 		return nil
 	}
 
-	log := log.FromContext(ctx).WithName("reconcileVersions")
+	log := logf.FromContext(ctx).WithName("reconcileVersions")
 
 	version, err := vs.GetVersion(ctx, cr, r.ServerVersion)
 	if err != nil {
@@ -412,7 +412,7 @@ func (r *PerconaServerMySQLReconciler) ensureUserSecrets(
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileUsers(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileUsers")
+	log := logf.FromContext(ctx).WithName("reconcileUsers")
 
 	secret := &corev1.Secret{}
 	nn := types.NamespacedName{Name: cr.Spec.SecretsName, Namespace: cr.Namespace}
@@ -647,7 +647,7 @@ func (r *PerconaServerMySQLReconciler) reconcileDatabase(
 	ctx context.Context,
 	cr *apiv1alpha1.PerconaServerMySQL,
 ) error {
-	log := log.FromContext(ctx).WithName("reconcileDatabase")
+	log := logf.FromContext(ctx).WithName("reconcileDatabase")
 
 	configHash, err := r.reconcileMySQLConfiguration(ctx, cr)
 	if err != nil {
@@ -692,7 +692,7 @@ type Exposer interface {
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileServicePerPod(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL, exposer Exposer) error {
-	_ = log.FromContext(ctx).WithName("reconcileServicePerPod")
+	_ = logf.FromContext(ctx).WithName("reconcileServicePerPod")
 
 	if !exposer.Exposed() {
 		return nil
@@ -714,7 +714,7 @@ func (r *PerconaServerMySQLReconciler) reconcileServicePerPod(ctx context.Contex
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileMySQLServices(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	_ = log.FromContext(ctx).WithName("reconcileMySQLServices")
+	_ = logf.FromContext(ctx).WithName("reconcileMySQLServices")
 
 	if err := k8s.EnsureService(ctx, r.Client, cr, mysql.UnreadyService(cr), r.Scheme, true); err != nil {
 		return errors.Wrap(err, "reconcile unready svc")
@@ -732,7 +732,7 @@ func (r *PerconaServerMySQLReconciler) reconcileMySQLServices(ctx context.Contex
 	return nil
 }
 func (r *PerconaServerMySQLReconciler) reconcileMySQLAutoConfig(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileMySQLAutoConfig")
+	log := logf.FromContext(ctx).WithName("reconcileMySQLAutoConfig")
 	var memory *resource.Quantity
 	var err error
 
@@ -789,7 +789,7 @@ func (r *PerconaServerMySQLReconciler) reconcileMySQLConfiguration(
 	ctx context.Context,
 	cr *apiv1alpha1.PerconaServerMySQL,
 ) (string, error) {
-	log := log.FromContext(ctx).WithName("reconcileMySQLConfiguration")
+	log := logf.FromContext(ctx).WithName("reconcileMySQLConfiguration")
 
 	cmName := mysql.ConfigMapName(cr)
 	nn := types.NamespacedName{Name: cmName, Namespace: cr.Namespace}
@@ -858,7 +858,7 @@ func (r *PerconaServerMySQLReconciler) reconcileMySQLConfiguration(
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileOrchestrator(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileOrchestrator")
+	log := logf.FromContext(ctx).WithName("reconcileOrchestrator")
 
 	if cr.Spec.MySQL.ClusterType == apiv1alpha1.ClusterTypeGR || !cr.OrchestratorEnabled() {
 		return nil
@@ -959,7 +959,7 @@ func (r *PerconaServerMySQLReconciler) reconcileOrchestratorServices(ctx context
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileHAProxy(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileHAProxy")
+	log := logf.FromContext(ctx).WithName("reconcileHAProxy")
 
 	if !cr.HAProxyEnabled() || cr.Spec.MySQL.ClusterType == apiv1alpha1.ClusterTypeGR {
 		return nil
@@ -1016,7 +1016,7 @@ func (r *PerconaServerMySQLReconciler) reconcileServices(ctx context.Context, cr
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileReplication(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileReplication")
+	log := logf.FromContext(ctx).WithName("reconcileReplication")
 
 	if err := r.reconcileGroupReplication(ctx, cr); err != nil {
 		return errors.Wrap(err, "reconcile group replication")
@@ -1045,7 +1045,7 @@ func (r *PerconaServerMySQLReconciler) reconcileReplication(ctx context.Context,
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileGroupReplication(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileGroupReplication")
+	log := logf.FromContext(ctx).WithName("reconcileGroupReplication")
 
 	if cr.Spec.MySQL.ClusterType != apiv1alpha1.ClusterTypeGR {
 		return nil
@@ -1098,7 +1098,7 @@ func reconcileReplicationSemiSync(
 	cl client.Reader,
 	cr *apiv1alpha1.PerconaServerMySQL,
 ) error {
-	log := log.FromContext(ctx).WithName("reconcileReplicationSemiSync")
+	log := logf.FromContext(ctx).WithName("reconcileReplicationSemiSync")
 
 	primary, err := getPrimaryFromOrchestrator(ctx, cr)
 	if err != nil {
@@ -1136,7 +1136,7 @@ func reconcileReplicationSemiSync(
 }
 
 func (r *PerconaServerMySQLReconciler) cleanupOutdatedServices(ctx context.Context, exposer Exposer) error {
-	log := log.FromContext(ctx).WithName("cleanupOutdatedServices")
+	log := logf.FromContext(ctx).WithName("cleanupOutdatedServices")
 
 	size := int(exposer.Size())
 	svcNames := make(map[string]struct{}, size)
@@ -1188,7 +1188,7 @@ func (r *PerconaServerMySQLReconciler) cleanupOutdatedStatefulSets(ctx context.C
 }
 
 func (r *PerconaServerMySQLReconciler) reconcileMySQLRouter(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("reconcileMySQLRouter")
+	log := logf.FromContext(ctx).WithName("reconcileMySQLRouter")
 
 	if cr.Spec.MySQL.ClusterType != apiv1alpha1.ClusterTypeGR {
 		return nil
@@ -1244,7 +1244,7 @@ func (r *PerconaServerMySQLReconciler) cleanupOutdated(ctx context.Context, cr *
 }
 
 func (r *PerconaServerMySQLReconciler) isGRReady(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) (bool, error) {
-	log := log.FromContext(ctx).WithName("GRStatus")
+	log := logf.FromContext(ctx).WithName("GRStatus")
 	if cr.Status.MySQL.Ready != cr.Spec.MySQL.Size {
 		return false, nil
 	}
@@ -1291,7 +1291,7 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 		nn := types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}
 		return writeStatus(ctx, r.Client, nn, cr.Status)
 	}
-	log := log.FromContext(ctx).WithName("reconcileCRStatus")
+	log := logf.FromContext(ctx).WithName("reconcileCRStatus")
 
 	mysqlStatus, err := appStatus(ctx, r.Client, cr.MySQLSpec().Size, mysql.MatchLabels(cr), cr.Status.MySQL.Version)
 	if err != nil {
@@ -1523,7 +1523,7 @@ func (r *PerconaServerMySQLReconciler) getPrimaryFromGR(ctx context.Context, cr 
 }
 
 func (r *PerconaServerMySQLReconciler) getPrimaryHost(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) (string, error) {
-	log := log.FromContext(ctx).WithName("getPrimaryHost")
+	log := logf.FromContext(ctx).WithName("getPrimaryHost")
 
 	if cr.Spec.MySQL.IsGR() {
 		return r.getPrimaryFromGR(ctx, cr)
@@ -1539,7 +1539,7 @@ func (r *PerconaServerMySQLReconciler) getPrimaryHost(ctx context.Context, cr *a
 }
 
 func (r *PerconaServerMySQLReconciler) stopAsyncReplication(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx).WithName("stopAsyncReplication")
+	log := logf.FromContext(ctx).WithName("stopAsyncReplication")
 
 	orcHost := orchestrator.APIHost(cr)
 	primary, err := getPrimaryFromOrchestrator(ctx, cr)
@@ -1599,7 +1599,7 @@ func (r *PerconaServerMySQLReconciler) stopAsyncReplication(ctx context.Context,
 }
 
 func (r *PerconaServerMySQLReconciler) startAsyncReplication(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL, replicaPass string) error {
-	log := log.FromContext(ctx).WithName("startAsyncReplication")
+	log := logf.FromContext(ctx).WithName("startAsyncReplication")
 
 	orcHost := orchestrator.APIHost(cr)
 	primary, err := getPrimaryFromOrchestrator(ctx, cr)
@@ -1647,7 +1647,7 @@ func (r *PerconaServerMySQLReconciler) startAsyncReplication(ctx context.Context
 }
 
 func (r *PerconaServerMySQLReconciler) restartGroupReplication(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL, replicaPass string) error {
-	log := log.FromContext(ctx).WithName("restartGroupReplication")
+	log := logf.FromContext(ctx).WithName("restartGroupReplication")
 
 	operatorPass, err := k8s.UserPassword(ctx, r.Client, cr, apiv1alpha1.UserOperator)
 	if err != nil {

--- a/controllers/perconaservermysql_controller.go
+++ b/controllers/perconaservermysql_controller.go
@@ -675,7 +675,8 @@ func (r *PerconaServerMySQLReconciler) reconcileDatabase(
 	}
 
 	if pmm := cr.Spec.PMM; pmm != nil && pmm.Enabled && !pmm.HasSecret(internalSecret) {
-		log.Info("Can't enable PMM, credentials are not setup correctly or secrets and internal secrets are our of sync")
+		log.Info(fmt.Sprintf(`Can't enable PMM: either "%s" key doesn't exist in the secrets, or secrets and internal secrets are out of sync`,
+		apiv1alpha1.UserPMMServerKey), "secrets", cr.Spec.SecretsName, "internalSecrets", cr.InternalSecretName())
 	}
 
 	return nil

--- a/controllers/perconaservermysqlbackup_controller.go
+++ b/controllers/perconaservermysqlbackup_controller.go
@@ -75,7 +75,7 @@ func (r *PerconaServerMySQLBackupReconciler) SetupWithManager(mgr ctrl.Manager) 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	l := log.FromContext(ctx).WithName("PerconaServerMySQLBackup")
+	log := log.FromContext(ctx).WithName("PerconaServerMySQLBackup")
 
 	rr := ctrl.Result{RequeueAfter: 5 * time.Second}
 
@@ -102,7 +102,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 			}
 
 			cr.Status = status
-			l.Info("Updating status", "state", cr.Status.State)
+			log.Info("Updating status", "state", cr.Status.State)
 			if err := r.Client.Status().Update(ctx, cr); err != nil {
 				return errors.Wrapf(err, "update %v", req.NamespacedName.String())
 			}
@@ -110,7 +110,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 			return nil
 		})
 		if err != nil {
-			l.Error(err, "failed to update status")
+			log.Error(err, "failed to update status")
 		}
 	}()
 
@@ -132,7 +132,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	if cluster.Spec.Backup == nil || !cluster.Spec.Backup.Enabled {
-		l.Info("spec.backup stanza not found in PerconaServerMySQL CustomResource or backup is disabled")
+		log.Info("spec.backup stanza not found in PerconaServerMySQL CustomResource or backup is disabled")
 		return rr, nil
 	}
 
@@ -142,7 +142,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	if cluster.Status.MySQL.State != apiv1alpha1.StateReady {
-		l.Info("Cluster is not ready", "cluster", cr.Name)
+		log.Info("Cluster is not ready", "cluster", cr.Name)
 		return rr, nil
 	}
 
@@ -154,7 +154,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	if k8serrors.IsNotFound(err) {
-		l.Info("Creating backup job", "jobName", nn.Name)
+		log.Info("Creating backup job", "jobName", nn.Name)
 
 		initImage, err := k8s.InitImage(ctx, r.Client, cluster, cluster.Spec.Backup)
 		if err != nil {
@@ -307,7 +307,7 @@ func getDestination(storage *apiv1alpha1.BackupStorageSpec, clusterName, creatio
 }
 
 func (r *PerconaServerMySQLBackupReconciler) getBackupSource(ctx context.Context, cluster *apiv1alpha1.PerconaServerMySQL) (string, error) {
-	l := log.FromContext(ctx).WithName("getBackupSource")
+	log := log.FromContext(ctx).WithName("getBackupSource")
 
 	operatorPass, err := k8s.UserPassword(ctx, r.Client, cluster, apiv1alpha1.UserOperator)
 	if err != nil {
@@ -322,7 +322,7 @@ func (r *PerconaServerMySQLBackupReconciler) getBackupSource(ctx context.Context
 	var source string
 	if len(top.Replicas) < 1 {
 		source = top.Primary
-		l.Info("no replicas found, using primary as the backup source", "primary", top.Primary)
+		log.Info("no replicas found, using primary as the backup source", "primary", top.Primary)
 	} else {
 		source = top.Replicas[0]
 	}
@@ -335,11 +335,11 @@ func (r *PerconaServerMySQLBackupReconciler) checkFinalizers(ctx context.Context
 	if cr.DeletionTimestamp == nil || cr.Status.State == apiv1alpha1.BackupStarting || cr.Status.State == apiv1alpha1.BackupRunning {
 		return
 	}
-	l := log.FromContext(ctx).WithName("checkFinalizers")
+	log := log.FromContext(ctx).WithName("checkFinalizers")
 
 	defer func() {
 		if err := r.Update(ctx, cr); err != nil {
-			l.Error(err, "failed to update finalizers for backup", "backup", cr.Name)
+			log.Error(err, "failed to update finalizers for backup", "backup", cr.Name)
 		}
 	}()
 
@@ -362,7 +362,7 @@ func (r *PerconaServerMySQLBackupReconciler) checkFinalizers(ctx context.Context
 			finalizers.Insert(finalizer)
 		}
 		if err != nil {
-			l.Error(err, "failed to run finalizer "+finalizer)
+			log.Error(err, "failed to run finalizer "+finalizer)
 			finalizers.Insert(finalizer)
 		}
 	}

--- a/controllers/perconaservermysqlbackup_controller.go
+++ b/controllers/perconaservermysqlbackup_controller.go
@@ -37,7 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
 	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
@@ -75,7 +75,7 @@ func (r *PerconaServerMySQLBackupReconciler) SetupWithManager(mgr ctrl.Manager) 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx).WithName("PerconaServerMySQLBackup")
+	log := logf.FromContext(ctx).WithName("PerconaServerMySQLBackup")
 
 	rr := ctrl.Result{RequeueAfter: 5 * time.Second}
 
@@ -307,7 +307,7 @@ func getDestination(storage *apiv1alpha1.BackupStorageSpec, clusterName, creatio
 }
 
 func (r *PerconaServerMySQLBackupReconciler) getBackupSource(ctx context.Context, cluster *apiv1alpha1.PerconaServerMySQL) (string, error) {
-	log := log.FromContext(ctx).WithName("getBackupSource")
+	log := logf.FromContext(ctx).WithName("getBackupSource")
 
 	operatorPass, err := k8s.UserPassword(ctx, r.Client, cluster, apiv1alpha1.UserOperator)
 	if err != nil {
@@ -335,7 +335,7 @@ func (r *PerconaServerMySQLBackupReconciler) checkFinalizers(ctx context.Context
 	if cr.DeletionTimestamp == nil || cr.Status.State == apiv1alpha1.BackupStarting || cr.Status.State == apiv1alpha1.BackupRunning {
 		return
 	}
-	log := log.FromContext(ctx).WithName("checkFinalizers")
+	log := logf.FromContext(ctx).WithName("checkFinalizers")
 
 	defer func() {
 		if err := r.Update(ctx, cr); err != nil {

--- a/controllers/perconaservermysqlrestore_controller.go
+++ b/controllers/perconaservermysqlrestore_controller.go
@@ -324,7 +324,7 @@ func (r *PerconaServerMySQLRestoreReconciler) removeBootstrapCondition(ctx conte
 		return r.Client.Status().Update(ctx, c)
 	})
 
-	log.Info("Set condition to false", "confition", apiv1alpha1.ConditionInnoDBClusterBootstrapped)
+	log.Info("Set condition to false", "condition", apiv1alpha1.ConditionInnoDBClusterBootstrapped)
 
 	return err
 }

--- a/controllers/perconaservermysqlrestore_controller.go
+++ b/controllers/perconaservermysqlrestore_controller.go
@@ -33,7 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/pkg/errors"
 
@@ -67,7 +67,7 @@ var ErrWaitingTermination error = errors.New("waiting for MySQL pods to terminat
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *PerconaServerMySQLRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx).WithName("PerconaServerMySQLRestore").WithValues("name", req.Name, "namespace", req.Namespace)
+	log := logf.FromContext(ctx).WithName("PerconaServerMySQLRestore").WithValues("name", req.Name, "namespace", req.Namespace)
 
 	cr := &apiv1alpha1.PerconaServerMySQLRestore{}
 	err := r.Client.Get(ctx, req.NamespacedName, cr)
@@ -280,7 +280,7 @@ func (r *PerconaServerMySQLRestoreReconciler) Reconcile(ctx context.Context, req
 }
 
 func (r *PerconaServerMySQLRestoreReconciler) deletePVCs(ctx context.Context, cluster *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	pvcs, err := k8s.PVCsByLabels(ctx, r.Client, mysql.MatchLabels(cluster))
 	if err != nil {
@@ -304,7 +304,7 @@ func (r *PerconaServerMySQLRestoreReconciler) deletePVCs(ctx context.Context, cl
 }
 
 func (r *PerconaServerMySQLRestoreReconciler) removeBootstrapCondition(ctx context.Context, cluster *apiv1alpha1.PerconaServerMySQL) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	err := k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
 		c := &apiv1alpha1.PerconaServerMySQL{}

--- a/controllers/perconaservermysqlrestore_controller.go
+++ b/controllers/perconaservermysqlrestore_controller.go
@@ -324,7 +324,7 @@ func (r *PerconaServerMySQLRestoreReconciler) removeBootstrapCondition(ctx conte
 		return r.Client.Status().Update(ctx, c)
 	})
 
-	l.Info(fmt.Sprintf("Set %s condition to false", apiv1alpha1.ConditionInnoDBClusterBootstrapped))
+	l.Info("Set condition to false", "confition", apiv1alpha1.ConditionInnoDBClusterBootstrapped)
 
 	return err
 }

--- a/pkg/mysqlsh/mysqlsh.go
+++ b/pkg/mysqlsh/mysqlsh.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	k8sexec "k8s.io/utils/exec"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/percona/percona-server-mysql-operator/pkg/innodbcluster"
 )
@@ -115,7 +115,7 @@ func (m *mysqlsh) CreateCluster(ctx context.Context, clusterName string) error {
 }
 
 func (m *mysqlsh) DoesClusterExist(ctx context.Context, clusterName string) bool {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	cmd := fmt.Sprintf("dba.getCluster('%s').status()", clusterName)
 	err := m.run(ctx, cmd)
@@ -151,7 +151,7 @@ func (m *mysqlsh) ClusterStatus(ctx context.Context, clusterName string) (innodb
 }
 
 func (m *mysqlsh) MemberState(ctx context.Context, clusterName, instance string) (innodbcluster.MemberState, error) {
-	log := log.FromContext(ctx).WithName("InnoDBCluster").WithValues("cluster", clusterName)
+	log := logf.FromContext(ctx).WithName("InnoDBCluster").WithValues("cluster", clusterName)
 
 	status, err := m.ClusterStatus(ctx, clusterName)
 	if err != nil {

--- a/pkg/mysqlsh/mysqlsh.go
+++ b/pkg/mysqlsh/mysqlsh.go
@@ -115,12 +115,12 @@ func (m *mysqlsh) CreateCluster(ctx context.Context, clusterName string) error {
 }
 
 func (m *mysqlsh) DoesClusterExist(ctx context.Context, clusterName string) bool {
-	l := log.FromContext(ctx)
+	log := log.FromContext(ctx)
 
 	cmd := fmt.Sprintf("dba.getCluster('%s').status()", clusterName)
 	err := m.run(ctx, cmd)
 	if err != nil {
-		l.Error(err, "failed to get cluster status")
+		log.Error(err, "failed to get cluster status")
 	}
 
 	return err == nil
@@ -151,14 +151,14 @@ func (m *mysqlsh) ClusterStatus(ctx context.Context, clusterName string) (innodb
 }
 
 func (m *mysqlsh) MemberState(ctx context.Context, clusterName, instance string) (innodbcluster.MemberState, error) {
-	l := log.FromContext(ctx).WithName("InnoDBCluster").WithValues("cluster", clusterName)
+	log := log.FromContext(ctx).WithName("InnoDBCluster").WithValues("cluster", clusterName)
 
 	status, err := m.ClusterStatus(ctx, clusterName)
 	if err != nil {
 		return innodbcluster.MemberStateOffline, errors.Wrap(err, "get cluster status")
 	}
 
-	l.V(1).Info("Cluster status", "status", status)
+	log.V(1).Info("Cluster status", "status", status)
 
 	member, ok := status.DefaultReplicaSet.Topology[instance]
 	if !ok {


### PR DESCRIPTION
[![K8SPS-236](https://badgen.net/badge/JIRA/K8SPS-236/green)](https://jira.percona.com/browse/K8SPS-236) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
In a couple of places, we use formatted log messages, breaking the whole structured logging thing we have.

**Cause:**
Misuse of our logging lib.

**Solution:**
Replace formatted messages with constant messages and proper use of KV pairs for the dynamic part of a log.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?