### PR TITLE
K8SPS-242: Refactor - Reorganize controllers

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,7 +39,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
-	"github.com/percona/percona-server-mysql-operator/controllers"
+	"github.com/percona/percona-server-mysql-operator/pkg/controller/ps"
+	"github.com/percona/percona-server-mysql-operator/pkg/controller/psbackup"
+	"github.com/percona/percona-server-mysql-operator/pkg/controller/psrestore"
 	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
 	"github.com/percona/percona-server-mysql-operator/pkg/platform"
 	//+kubebuilder:scaffold:imports
@@ -111,7 +113,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.PerconaServerMySQLReconciler{
+	if err = (&ps.PerconaServerMySQLReconciler{
 		Client:        nsClient,
 		Scheme:        mgr.GetScheme(),
 		ServerVersion: serverVersion,
@@ -119,7 +121,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "PerconaServerMySQL")
 		os.Exit(1)
 	}
-	if err = (&controllers.PerconaServerMySQLBackupReconciler{
+	if err = (&psbackup.PerconaServerMySQLBackupReconciler{
 		Client:        nsClient,
 		Scheme:        mgr.GetScheme(),
 		ServerVersion: serverVersion,
@@ -127,7 +129,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "PerconaServerMySQLBackup")
 		os.Exit(1)
 	}
-	if err = (&controllers.PerconaServerMySQLRestoreReconciler{
+	if err = (&psrestore.PerconaServerMySQLRestoreReconciler{
 		Client:        nsClient,
 		Scheme:        mgr.GetScheme(),
 		ServerVersion: serverVersion,

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package ps
 
 import (
 	"bytes"
@@ -46,6 +46,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
+	"github.com/percona/percona-server-mysql-operator/pkg/controller/psrestore"
 	"github.com/percona/percona-server-mysql-operator/pkg/haproxy"
 	"github.com/percona/percona-server-mysql-operator/pkg/innodbcluster"
 	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
@@ -139,7 +140,7 @@ func (r *PerconaServerMySQLReconciler) applyFinalizers(ctx context.Context, cr *
 
 		if err != nil {
 			switch err {
-			case ErrWaitingTermination:
+			case psrestore.ErrWaitingTermination:
 				log.Info("waiting for pods to be deleted", "finalizer", f)
 			default:
 				log.Error(err, "failed to run finalizer", "finalizer", f)
@@ -253,7 +254,7 @@ func (r *PerconaServerMySQLReconciler) deleteMySQLPods(ctx context.Context, cr *
 		log.Info("sts replicaset downscaled", "sts", sts)
 	}
 
-	return ErrWaitingTermination
+	return psrestore.ErrWaitingTermination
 }
 
 func (r *PerconaServerMySQLReconciler) doReconcile(

--- a/pkg/controller/psbackup/controller.go
+++ b/pkg/controller/psbackup/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package psbackup
 
 import (
 	"bytes"

--- a/pkg/controller/psrestore/controller.go
+++ b/pkg/controller/psrestore/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package psrestore
 
 import (
 	"context"

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"path/filepath"


### PR DESCRIPTION
[![K8SPS-242](https://badgen.net/badge/JIRA/K8SPS-242/green)](https://jira.percona.com/browse/K8SPS-242) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
Having all the controllers in a single package we don't have a clean separation of concerns and it is harder to test.

**Solution:**
Reorganize controllers from
```
controllers
	perconaservermysql_controller.go
        perconaservermysqlbackup_controller.go
        perconaservermysqlrestore_controller.go
```
to
```
pkg
	controller
		ps
			controller.go
		psbackup
			controller.go
		psrestore
			controller.go
```

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?