### PR TITLE
CLOUD-775 - Fix cancelation of parallel pipeline build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ void initTests() {
     def records = readCSV file: 'e2e-tests/run-pr.csv'
 
     for (int i=0; i<records.size(); i++) {
-        tests.add(["name": records[i][0], "cluster": "NA", "result": "NA", "time": "0"])
+        tests.add(["name": records[i][0], "cluster": "NA", "result": "skipped", "time": "0"])
     }
 
     markPassedTests()
@@ -151,7 +151,7 @@ void makeReport() {
         def testTime = tests[i]["time"]
         def testUrl = "${testUrlPrefix}/${env.GIT_BRANCH}/${env.GIT_SHORT_COMMIT}/${testName}.log"
 
-        if (tests[i]["result"] != "NA") {
+        if (tests[i]["result"] != "skipped") {
             startedTestAmount++
         }
         TestsReport = TestsReport + "\r\n| "+ testName +" | ["+ testResult +"]("+ testUrl +") |"
@@ -165,7 +165,7 @@ void clusterRunner(String cluster) {
     def clusterCreated=0
 
     for (int i=0; i<tests.size(); i++) {
-        if (tests[i]["result"] == "NA" && currentBuild.nextBuild == null) {
+        if (tests[i]["result"] == "skipped" && currentBuild.nextBuild == null) {
             tests[i]["result"] = "failure"
             tests[i]["cluster"] = cluster
             if (clusterCreated == 0) {


### PR DESCRIPTION
[![CLOUD-775](https://badgen.net/badge/JIRA/CLOUD-775/green)](https://jira.percona.com/browse/CLOUD-775) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Currently in dev pipelines when a new commit is pushed we delete the associated kubernetes clusters for the previous build, but if the pipeline was in its parallel stage in that case the jenkins executor might get stuck so the executor spot instance will be killed only later.*

**Solution:**
*In the clusterRunner() and in runTest() when the test needs to be re-run on next test run check if there is a new build scheduled and if yes in that case do not continue running current tests.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?