### PR TITLE
K8SPS-168: Check if the specified CM issuer exist

### DIFF
--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -42,7 +42,6 @@ import (
 	k8sexec "k8s.io/utils/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
@@ -1559,7 +1558,6 @@ func (r *PerconaServerMySQLReconciler) createSSLByCertManager(ctx context.Contex
 			Name:      issuerName,
 		}, isr)
 		if k8serrors.IsNotFound(err) {
-			log.FromContext(ctx).Error(err, "Can't find specified cert-manager issuer", "issuer", issuerName)
 			return err
 		}
 

--- a/pkg/controller/ps/tls_test.go
+++ b/pkg/controller/ps/tls_test.go
@@ -55,7 +55,10 @@ var _ = Describe("Finalizer delete-ssl", Ordered, func() {
 			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
 		})
 
-		// This way we simulate cert-manager creating secrets
+		// This way we simulate cert-manager creating secrets.
+		// Normally these secrets are created by cert-manager controller after creating
+		// the certificates but in envtest environment we don't (and can't have) have cert-manager running.
+		// We are creating secrets manually to make operator think they're created by cert-manager,
 		go func() {
 			defer GinkgoRecover()
 


### PR DESCRIPTION
[![K8SPS-168](https://badgen.net/badge/JIRA/K8SPS-168/green)](https://jira.percona.com/browse/K8SPS-168) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

---
**Problem:**
When the wrong `spec.tls.issuerConf` is specified, we don't provide a clear error message.

**Solution:**
Besides having a more clear error message, when we get issuerConf from the user, first check if the issuer is created and ready before proceeding.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?