### PR TITLE
K8SPS-209: Remove HAProxy outdated service

### DIFF
--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -1060,6 +1060,11 @@ func (r *PerconaServerMySQLReconciler) cleanupOutdated(ctx context.Context, cr *
 		return errors.Wrap(err, "cleanup Orchestrator services")
 	}
 
+	hapExposer := haproxy.Exposer(*cr)
+	if err := r.cleanupOutdatedServices(ctx, &hapExposer); err != nil {
+		return errors.Wrap(err, "cleanup Orchestrator services")
+	}
+
 	if err := r.cleanupOutdatedStatefulSets(ctx, cr); err != nil {
 		return errors.Wrap(err, "cleanup statefulsets")
 	}

--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -25,6 +25,7 @@ import (
 	gs "github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -358,6 +359,88 @@ var _ = Describe("Unsafe configurations", Ordered, func() {
 			}, time.Second*15, time.Millisecond*250).Should(BeTrue())
 
 			Expect(*sts.Spec.Replicas).Should(Equal(int32(1)))
+		})
+	})
+})
+
+var _ = Describe("Cleanup outdated", Ordered, func() {
+	ctx := context.Background()
+
+	crName := "cleanup-outdated"
+	ns := crName
+	crNamespacedName := types.NamespacedName{Name: crName, Namespace: ns}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: ns,
+		},
+	}
+
+	BeforeAll(func() {
+		By("Creating the Namespace to perform the tests")
+		err := k8sClient.Create(ctx, namespace)
+		Expect(err).To(Not(HaveOccurred()))
+	})
+
+	AfterAll(func() {
+		By("Deleting the Namespace to perform the tests")
+		_ = k8sClient.Delete(ctx, namespace)
+	})
+
+	Context("Cleanup outdated HAProxy service", func() {
+		cr, err := readDefaultCR(crName, ns)
+		cr.Spec.MySQL.ClusterType = psv1alpha1.ClusterTypeAsync
+		cr.Spec.Proxy.HAProxy.Enabled = true
+		cr.Spec.AllowUnsafeConfig = false
+		It("should read and create defautl cr.yaml", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
+		})
+
+		svcName := crName + "-haproxy"
+
+		It("should reconcile and create HAProxy service", func() {
+			_, err = reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			svc := &corev1.Service{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: cr.Namespace,
+					Name:      svcName,
+				}, svc)
+
+				return err == nil
+			}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+
+			Expect(svc.Name).Should(Equal(svcName))
+		})
+
+		When("HAPRoxy is disabled", Ordered, func() {
+			It("should remove outdated HAProxy service", func() {
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, crNamespacedName, cr)
+					return err == nil
+				}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+
+				cr.Spec.Proxy.HAProxy.Enabled = false
+				cr.Spec.AllowUnsafeConfig = true
+				Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+				_, err = reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				svc := &corev1.Service{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Namespace: cr.Namespace,
+						Name:      svcName,
+					}, svc)
+
+					return k8serrors.IsNotFound(err)
+				}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+			})
 		})
 	})
 })

--- a/pkg/controller/ps/tls_test.go
+++ b/pkg/controller/ps/tls_test.go
@@ -42,12 +42,6 @@ var _ = Describe("Finalizer delete-ssl", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterAll(func() {
-		time.Sleep(60 * time.Second)
-		By("Deleting the Namespace to perform the tests")
-		_ = k8sClient.Delete(ctx, namespace)
-	})
-
 	Context("delete-ssl finalizer not set", Ordered, func() {
 		cr, err := readDefaultCR(crName, ns)
 		It("should read and create defautl cr.yaml", func() {

--- a/pkg/haproxy/haproxy.go
+++ b/pkg/haproxy/haproxy.go
@@ -25,6 +25,37 @@ const (
 	PortProxyProtocol = 3309
 )
 
+type Exposer apiv1alpha1.PerconaServerMySQL
+
+func (e *Exposer) Exposed() bool {
+	cr := apiv1alpha1.PerconaServerMySQL(*e)
+	return cr.HAProxyEnabled()
+}
+
+func (e *Exposer) Name(index string) string {
+	cr := apiv1alpha1.PerconaServerMySQL(*e)
+	return Name(&cr)
+}
+
+func (e *Exposer) Size() int32 {
+	return e.Spec.Proxy.HAProxy.Size
+}
+
+func (e *Exposer) Labels() map[string]string {
+	cr := apiv1alpha1.PerconaServerMySQL(*e)
+	return MatchLabels(&cr)
+}
+
+func (e *Exposer) Service(name string) *corev1.Service {
+	cr := apiv1alpha1.PerconaServerMySQL(*e)
+	return Service(&cr)
+}
+
+func (e *Exposer) SaveOldMeta() bool {
+	cr := apiv1alpha1.PerconaServerMySQL(*e)
+	return cr.Spec.Proxy.HAProxy.Expose.SaveOldMeta()
+}
+
 func Name(cr *apiv1alpha1.PerconaServerMySQL) string {
 	return cr.Name + "-" + componentName
 }


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
When HAProxy is disabled, its service is not removed.

**Solution:**
Clean up outdated HAProxy service via its `Exposer` (like MySQL and Orchestrator services are cleaned up)

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?
