### PR TITLE
 K8SPS-253: Fix flaky integration tests

### DIFF
--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -243,8 +243,8 @@ var _ = Describe("Sidecars", Ordered, func() {
 var _ = Describe("Unsafe configurations", Ordered, func() {
 	ctx := context.Background()
 
-	crName := "unsafe-configs"
-	ns := crName
+	const crName = "unsafe-configs"
+	const ns = crName
 	crNamespacedName := types.NamespacedName{Name: crName, Namespace: ns}
 
 	namespace := &corev1.Namespace{


### PR DESCRIPTION
[![K8SPS-253](https://badgen.net/badge/JIRA/K8SPS-253/green)](https://jira.percona.com/browse/K8SPS-253) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Flaky delete-ssl finalizer integration tests.

**Cause**
"Simulating cert-manager" in `delete-ssl` finalizer test. The goroutine that is spun and the necessary `time.sleep` simply introduces non-determinism into the test suite.

**Solution**
Remove the case that needs "simulating cert-manager". This case simply requires that is covered with e2e test since running cert-manager operator is needed. This should be covered with this task https://jira.percona.com/browse/K8SPS-154

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?