### PR TITLE
K8SPS-73 - Add gr-one-pod test

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -133,8 +133,7 @@ get_cr() {
 		| yq eval "$(printf '.spec.proxy.haproxy.image="%s"' "${IMAGE_HAPROXY}")" - \
 		| yq eval "$(printf '.spec.pmm.image="%s"' "${IMAGE_PMM}")" - \
 		| if [ -n "${MINIKUBE}" ]; then
-			yq eval '(.. | select(has("antiAffinityTopologyKey")).antiAffinityTopologyKey) |= "none"' - \
-				| yq eval '.spec.proxy.haproxy.resources.requests.cpu="300m"' -
+			yq eval '(.. | select(has("antiAffinityTopologyKey")).antiAffinityTopologyKey) |= "none"' -
 		else
 			yq eval -
 		fi
@@ -181,6 +180,12 @@ get_mysql_service() {
 	local cluster=$1
 
 	echo "${cluster}-mysql"
+}
+
+get_router_service() {
+	local cluster=$1
+
+	echo "${cluster}-router"
 }
 
 get_haproxy_svc() {
@@ -312,7 +317,27 @@ wait_cluster_consistency() {
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.orchestrator.ready}')" == "${orc_size}" &&
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.orchestrator.state}')" == "ready" &&
 	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.state}')" == "ready" ]]; do
-		echo 'waiting for cluster readyness'
+		echo 'waiting for cluster readyness (async)'
+		sleep 15
+	done
+}
+
+wait_cluster_consistency_gr() {
+	local cluster_name=${1}
+	local cluster_size=${2}
+	local router_size=${3}
+
+	if [ -z "${router_size}" ]; then
+		router_size=3
+	fi
+
+	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
+	until [[ "$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.state}')" == "ready" &&
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.mysql.ready}')" == "${cluster_size}" &&
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.router.ready}')" == "${router_size}" &&
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.router.state}')" == "ready" &&
+	"$(kubectl get ps "${cluster_name}" -n "${NAMESPACE}" -o jsonpath='{.status.state}')" == "ready" ]]; do
+		echo 'waiting for cluster readyness (group replication)'
 		sleep 15
 	done
 }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -302,7 +302,7 @@ get_service_ip() {
 	kubectl get service/$service -n "${NAMESPACE}" -o 'jsonpath={.status.loadBalancer.ingress[].hostname}'
 }
 
-wait_cluster_consistency() {
+wait_cluster_consistency_async() {
 	local cluster_name=${1}
 	local cluster_size=${2}
 	local orc_size=${3}

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -6,6 +6,7 @@ demand-backup
 gr-demand-backup
 gr-ignore-annotations
 gr-init-deploy
+gr-one-pod
 gr-scaling
 gr-tls-cert-manager
 haproxy

--- a/e2e-tests/tests/gr-one-pod/00-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/00-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermysqls.ps.percona.com
+spec:
+  group: ps.percona.com
+  names:
+    kind: PerconaServerMySQL
+    listKind: PerconaServerMySQLList
+    plural: perconaservermysqls
+    shortNames:
+    - ps
+    singular: perconaservermysql
+  scope: Namespaced
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: percona-server-mysql-operator
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/e2e-tests/tests/gr-one-pod/00-deploy-operator.yaml
+++ b/e2e-tests/tests/gr-one-pod/00-deploy-operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      apply_s3_storage_secrets
+      deploy_operator
+      deploy_non_tls_cluster_secrets
+      deploy_tls_cluster_secrets
+      deploy_client
+      deploy_minio
+    timeout: 300

--- a/e2e-tests/tests/gr-one-pod/01-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/01-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 240
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-one-pod-mysql
+status:
+  observedGeneration: 1
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generation: 1
+  labels:
+    app.kubernetes.io/component: router
+    app.kubernetes.io/instance: gr-one-pod
+    app.kubernetes.io/managed-by: percona-server-operator
+    app.kubernetes.io/name: percona-server
+    app.kubernetes.io/part-of: percona-server
+  name: gr-one-pod-router
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-one-pod
+spec:
+  allowUnsafeConfigurations: true
+  mysql:
+    clusterType: group-replication
+    size: 1
+  proxy:
+    router:
+      size: 1
+status:
+  mysql:
+    ready: 1
+    size: 1
+    state: ready
+  orchestrator: {}
+  router:
+    ready: 1
+    size: 1
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-one-pod/01-create-cluster.yaml
+++ b/e2e-tests/tests/gr-one-pod/01-create-cluster.yaml
@@ -9,13 +9,12 @@ commands:
       source ../../functions
 
       get_cr \
-        | yq eval '.spec.mysql.clusterType="async"' - \
+        | yq eval '.spec.mysql.clusterType="group-replication"' - \
         | yq eval '.spec.allowUnsafeConfigurations=true' - \
         | yq eval '.spec.mysql.size=1' - \
-        | yq eval '.spec.proxy.haproxy.enabled=true' - \
-        | yq eval '.spec.proxy.haproxy.size=1' - \
-        | yq eval '.spec.orchestrator.enabled=true' - \
-        | yq eval '.spec.orchestrator.size=1' - \
+        | yq eval '.spec.proxy.haproxy.enabled=false' - \
+        | yq eval '.spec.proxy.router.size=1' - \
+        | yq eval '.spec.orchestrator.enabled=false' - \
         | yq eval '.spec.backup.storages.minio.type="s3"' - \
         | yq eval '.spec.backup.storages.minio.s3.bucket="operator-testing"' - \
         | yq eval '.spec.backup.storages.minio.s3.credentialsSecret="minio-secret"' - \

--- a/e2e-tests/tests/gr-one-pod/01-errors.yml
+++ b/e2e-tests/tests/gr-one-pod/01-errors.yml
@@ -1,0 +1,9 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-one-pod-orc
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-one-pod-haproxy

--- a/e2e-tests/tests/gr-one-pod/02-write-data.yaml
+++ b/e2e-tests/tests/gr-one-pod/02-write-data.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      run_mysql \
+      	"CREATE DATABASE IF NOT EXISTS myDB; CREATE TABLE IF NOT EXISTS myDB.myTable (id int PRIMARY KEY)" \
+      	"-h $(get_router_service $(get_cluster_name)) -uroot -proot_password"
+
+      run_mysql \
+      	"INSERT myDB.myTable (id) VALUES (100500)" \
+      	"-h $(get_router_service $(get_cluster_name)) -uroot -proot_password"

--- a/e2e-tests/tests/gr-one-pod/03-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/03-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: PerconaServerMySQLBackup
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: gr-one-pod-minio
+status:
+  state: Succeeded

--- a/e2e-tests/tests/gr-one-pod/03-create-backup-minio.yaml
+++ b/e2e-tests/tests/gr-one-pod/03-create-backup-minio.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLBackup
+metadata:
+  name: gr-one-pod-minio
+spec:
+  clusterName: gr-one-pod
+  storageName: minio

--- a/e2e-tests/tests/gr-one-pod/04-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/04-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio
+data:
+  data: ""

--- a/e2e-tests/tests/gr-one-pod/04-delete-data.yaml
+++ b/e2e-tests/tests/gr-one-pod/04-delete-data.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      run_mysql \
+      	"TRUNCATE TABLE myDB.myTable" \
+      	"-h $(get_router_service $(get_cluster_name)) -uroot -proot_password"
+
+      data=$(run_mysql "SELECT * FROM myDB.myTable" "-h $(get_router_service $(get_cluster_name)) -uroot -proot_password")
+      kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio --from-literal=data="${data}"

--- a/e2e-tests/tests/gr-one-pod/05-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/05-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 360
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-one-pod
+status:
+  mysql:
+    ready: 1
+    size: 1
+    state: ready
+  orchestrator: {}
+  router:
+    ready: 1
+    size: 1
+    state: ready
+  state: ready
+---
+kind: PerconaServerMySQLRestore
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: gr-one-pod-restore-minio
+status:
+  state: Succeeded

--- a/e2e-tests/tests/gr-one-pod/05-restore-from-minio.yaml
+++ b/e2e-tests/tests/gr-one-pod/05-restore-from-minio.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLRestore
+metadata:
+  name: gr-one-pod-restore-minio
+spec:
+  clusterName: gr-one-pod
+  backupName: gr-one-pod-minio

--- a/e2e-tests/tests/gr-one-pod/06-assert.yaml
+++ b/e2e-tests/tests/gr-one-pod/06-assert.yaml
@@ -1,0 +1,57 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio
+data:
+  data: "100500"
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-one-pod-mysql
+status:
+  observedGeneration: 3
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: router
+    app.kubernetes.io/instance: gr-one-pod
+    app.kubernetes.io/managed-by: percona-server-operator
+    app.kubernetes.io/name: percona-server
+    app.kubernetes.io/part-of: percona-server
+  name: gr-one-pod-router
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  observedGeneration: 3
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-one-pod
+status:
+  mysql:
+    ready: 1
+    size: 1
+    state: ready
+  orchestrator: {}
+  router:
+    ready: 1
+    size: 1
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-one-pod/06-read-data.yaml
+++ b/e2e-tests/tests/gr-one-pod/06-read-data.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      wait_cluster_consistency_gr "${test_name}" "1" "1"
+
+      data=$(run_mysql "SELECT * FROM myDB.myTable" "-h $(get_router_service $(get_cluster_name)) -uroot -proot_password")
+      kubectl create configmap -n "${NAMESPACE}" 06-read-data-minio --from-literal=data="${data}"
+    timeout: 120

--- a/e2e-tests/tests/gr-one-pod/07-drop-finalizer.yaml
+++ b/e2e-tests/tests/gr-one-pod/07-drop-finalizer.yaml
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-one-pod
+  finalizers: []

--- a/e2e-tests/tests/monitoring/02-assert.yaml
+++ b/e2e-tests/tests/monitoring/02-assert.yaml
@@ -134,3 +134,4 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready

--- a/e2e-tests/tests/one-pod/05-assert.yaml
+++ b/e2e-tests/tests/one-pod/05-assert.yaml
@@ -15,6 +15,7 @@ status:
     ready: 1
     size: 1
     state: ready
+  state: ready
 ---
 kind: PerconaServerMySQLRestore
 apiVersion: ps.percona.com/v1alpha1

--- a/e2e-tests/tests/one-pod/06-assert.yaml
+++ b/e2e-tests/tests/one-pod/06-assert.yaml
@@ -46,3 +46,4 @@ status:
     ready: 1
     size: 1
     state: ready
+  state: ready

--- a/e2e-tests/tests/one-pod/06-read-data.yaml
+++ b/e2e-tests/tests/one-pod/06-read-data.yaml
@@ -8,8 +8,5 @@ commands:
 
       source ../../functions
 
-      wait_cluster_consistency "${test_name}" "1" "1"
-
       data=$(run_mysql "SELECT * FROM myDB.myTable" "-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password")
       kubectl create configmap -n "${NAMESPACE}" 06-read-data-minio --from-literal=data="${data}"
-    timeout: 120

--- a/e2e-tests/tests/scaling/01-assert.yaml
+++ b/e2e-tests/tests/scaling/01-assert.yaml
@@ -41,3 +41,4 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready

--- a/e2e-tests/tests/scaling/01-create-cluster.yaml
+++ b/e2e-tests/tests/scaling/01-create-cluster.yaml
@@ -17,6 +17,3 @@ commands:
         | yq eval '.spec.orchestrator.size=3' - \
         | yq eval '.spec.orchestrator.affinity.antiAffinityTopologyKey="none"' - \
         | kubectl -n "${NAMESPACE}" apply -f -
-
-      wait_cluster_consistency "${test_name}" "3" "3"
-    timeout: 420

--- a/e2e-tests/tests/scaling/06-assert.yaml
+++ b/e2e-tests/tests/scaling/06-assert.yaml
@@ -41,3 +41,4 @@ status:
     ready: 5
     size: 5
     state: ready
+  state: ready

--- a/e2e-tests/tests/scaling/06-scale-up.yaml
+++ b/e2e-tests/tests/scaling/06-scale-up.yaml
@@ -15,6 +15,3 @@ commands:
         | yq eval '.spec.orchestrator.enabled=true' - \
         | yq eval '.spec.orchestrator.size=5' - \
         | kubectl -n "${NAMESPACE}" apply -f -
-
-      wait_cluster_consistency "${test_name}" "5" "5"
-    timeout: 360

--- a/e2e-tests/tests/scaling/08-assert.yaml
+++ b/e2e-tests/tests/scaling/08-assert.yaml
@@ -41,6 +41,7 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/e2e-tests/tests/scaling/08-scale-down.yaml
+++ b/e2e-tests/tests/scaling/08-scale-down.yaml
@@ -15,6 +15,3 @@ commands:
         | yq eval '.spec.orchestrator.enabled=true' - \
         | yq eval '.spec.orchestrator.size=3' - \
         | kubectl -n "${NAMESPACE}" apply -f -
-
-      wait_cluster_consistency "${test_name}" "3" "3"
-    timeout: 120

--- a/e2e-tests/tests/semi-sync/01-assert.yaml
+++ b/e2e-tests/tests/semi-sync/01-assert.yaml
@@ -41,3 +41,4 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready

--- a/e2e-tests/tests/service-per-pod/01-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/01-assert.yaml
@@ -41,6 +41,7 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready
 ---
 apiVersion: v1
 kind: Service

--- a/e2e-tests/tests/service-per-pod/04-assert.yaml
+++ b/e2e-tests/tests/service-per-pod/04-assert.yaml
@@ -41,6 +41,7 @@ status:
     ready: 3
     size: 3
     state: ready
+  state: ready
 ---
 apiVersion: v1
 kind: Service

--- a/e2e-tests/tests/sidecars/01-create-cluster.yaml
+++ b/e2e-tests/tests/sidecars/01-create-cluster.yaml
@@ -16,5 +16,5 @@ commands:
       	| yq eval '.spec.mysql.sidecarPVCs = [{"name": "pvc-vol", "spec": {"resources": {"requests": {"storage": "1G"}}}}]' - \
       	| kubectl -n "${NAMESPACE}" apply -f -
 
-      wait_cluster_consistency "${test_name}" "3" "3"
+      wait_cluster_consistency_async "${test_name}" "3" "3"
     timeout: 240

--- a/e2e-tests/tests/users/04-check-cluster.yaml
+++ b/e2e-tests/tests/users/04-check-cluster.yaml
@@ -9,7 +9,7 @@ commands:
       source ../../functions
 
       sleep 20 # wait for cluster status to change to initializing
-      wait_cluster_consistency "${test_name}" "3" "3"
+      wait_cluster_consistency_async "${test_name}" "3" "3"
       mysql_args="-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password_updated"
       users=($(get_mysql_users "${mysql_args}"))
 


### PR DESCRIPTION
[![K8SPS-73](https://badgen.net/badge/JIRA/K8SPS-73/green)](https://jira.percona.com/browse/K8SPS-73) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
*With this we are adding `gr-one-pod` test to check group replication unsafe config with 1 mysql 1 router pods and backup/restore.
Also we remove setting in functions for minikube where we reduce `.spec.proxy.haproxy.resources.requests.cpu` because now we have increased our minikube settings in jenkins.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?