### PR TITLE
K8SPS-228 - Change async-ignore-annotations test to use ClusterIP

### DIFF
--- a/e2e-tests/tests/async-ignore-annotations/01-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/01-assert.yaml
@@ -100,4 +100,4 @@ spec:
     app.kubernetes.io/name: percona-server
     app.kubernetes.io/part-of: percona-server
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e-tests/tests/async-ignore-annotations/01-create-cluster.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/01-create-cluster.yaml
@@ -11,7 +11,7 @@ commands:
       get_cr \
         | yq eval '.spec.mysql.clusterType="async"' - \
         | yq eval '.spec.mysql.expose.enabled=true' - \
-        | yq eval '.spec.mysql.expose.type="LoadBalancer"' - \
-        | yq eval '.spec.proxy.haproxy.expose.type="LoadBalancer"' - \
-        | yq eval '.spec.orchestrator.expose.type="LoadBalancer"' - \
+        | yq eval '.spec.mysql.expose.type="ClusterIP"' - \
+        | yq eval '.spec.proxy.haproxy.expose.type="ClusterIP"' - \
+        | yq eval '.spec.orchestrator.expose.type="ClusterIP"' - \
         | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/async-ignore-annotations/02-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/02-assert.yaml
@@ -49,7 +49,7 @@ spec:
     app.kubernetes.io/name: percona-server
     app.kubernetes.io/part-of: percona-server
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -96,7 +96,7 @@ spec:
     app.kubernetes.io/name: percona-server
     app.kubernetes.io/part-of: percona-server
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -140,4 +140,4 @@ spec:
     app.kubernetes.io/name: percona-server
     app.kubernetes.io/part-of: percona-server
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e-tests/tests/async-ignore-annotations/04-add-annotations-to-service-via-cr.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/04-add-annotations-to-service-via-cr.yaml
@@ -9,14 +9,14 @@ commands:
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "add", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": LoadBalancer,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
+        -p '[{"op": "add", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": ClusterIP,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "add", "path": "/spec/proxy/haproxy/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
+        -p '[{"op": "add", "path": "/spec/proxy/haproxy/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "add", "path": "/spec/orchestrator/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
+        -p '[{"op": "add", "path": "/spec/orchestrator/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http","service.beta.kubernetes.io/aws-load-balancer-backend": "test-type"}, "labels": {"rack": "rack-22","rack-test": "rack-test-22"}}}]'
 
     timeout: 30

--- a/e2e-tests/tests/async-ignore-annotations/04-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/04-assert.yaml
@@ -53,7 +53,7 @@ spec:
     rack: rack-22
     rack-test: rack-test-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -104,7 +104,7 @@ spec:
     rack: rack-22
     rack-test: rack-test-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -152,4 +152,4 @@ spec:
     rack: rack-22
     rack-test: rack-test-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e-tests/tests/async-ignore-annotations/05-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/05-assert.yaml
@@ -50,7 +50,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -98,7 +98,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -143,4 +143,4 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e-tests/tests/async-ignore-annotations/05-delete-annotations.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/05-delete-annotations.yaml
@@ -9,14 +9,14 @@ commands:
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": LoadBalancer,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
+        -p '[{"op": "replace", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": ClusterIP,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/proxy/haproxy/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
+        -p '[{"op": "replace", "path": "/spec/proxy/haproxy/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/orchestrator/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
+        -p '[{"op": "replace", "path": "/spec/orchestrator/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"}, "labels": {"rack": "rack-22"}}}]'
 
     timeout: 30

--- a/e2e-tests/tests/async-ignore-annotations/06-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/06-assert.yaml
@@ -50,7 +50,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -98,7 +98,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -143,4 +143,4 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP

--- a/e2e-tests/tests/async-ignore-annotations/06-update-annotation.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/06-update-annotation.yaml
@@ -9,14 +9,14 @@ commands:
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": LoadBalancer,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
+        -p '[{"op": "replace", "path": "/spec/mysql/expose", "value": {"enabled": true, "type": ClusterIP,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/proxy/haproxy/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
+        -p '[{"op": "replace", "path": "/spec/proxy/haproxy/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
 
       kubectl -n "${NAMESPACE}" patch ps "$(get_cluster_name)" \
         --type json \
-        -p '[{"op": "replace", "path": "/spec/orchestrator/expose", "value": {"type": LoadBalancer ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
+        -p '[{"op": "replace", "path": "/spec/orchestrator/expose", "value": {"type": ClusterIP ,"annotations": {"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http-test"}, "labels": {"rack": "rack-22-test"}}}]'
 
     timeout: 30

--- a/e2e-tests/tests/async-ignore-annotations/07-assert.yaml
+++ b/e2e-tests/tests/async-ignore-annotations/07-assert.yaml
@@ -48,7 +48,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -94,7 +94,7 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -137,5 +137,5 @@ spec:
     app.kubernetes.io/part-of: percona-server
     rack: rack-22-test
   sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*async-ignore-annotations test is using LoadBalancer for services when it is probably not needed.*

**Solution:**
*Switch to ClusterIP.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
