### PR TITLE
K8SPS-280: Improve full cluster crash recovery

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -85,8 +85,9 @@ func (t ClusterType) isValid() bool {
 }
 
 type MySQLSpec struct {
-	ClusterType ClusterType            `json:"clusterType,omitempty"`
-	Expose      ServiceExposeTogglable `json:"expose,omitempty"`
+	ClusterType  ClusterType            `json:"clusterType,omitempty"`
+	Expose       ServiceExposeTogglable `json:"expose,omitempty"`
+	AutoRecovery bool                   `json:"autoRecovery,omitempty"`
 
 	Sidecars       []corev1.Container `json:"sidecars,omitempty"`
 	SidecarVolumes []corev1.Volume    `json:"sidecarVolumes,omitempty"`

--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -480,7 +480,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersi
 		cr.Spec.MySQL.LivenessProbe.SuccessThreshold = 1
 	}
 	if cr.Spec.MySQL.LivenessProbe.TimeoutSeconds == 0 {
-		cr.Spec.MySQL.LivenessProbe.TimeoutSeconds = 30
+		cr.Spec.MySQL.LivenessProbe.TimeoutSeconds = 10
 	}
 
 	if cr.Spec.MySQL.ReadinessProbe.InitialDelaySeconds == 0 {

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -405,9 +405,14 @@ if [[ -f /var/lib/mysql/full-cluster-crash ]]; then
 	namespace=$(</var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
 	echo "######FULL_CLUSTER_CRASH:${node_name}######"
-	echo "You are in a full cluster crash. Operator will attempt to fix the issue automatically."
+	echo "You are in a full cluster crash. Operator will attempt to fix the issue automatically if you have spec.mysql.autoRecovery enabled."
 	echo "MySQL pods will be up and running in read only mode."
 	echo "Latest GTID_EXECUTED on this node is ${gtid_executed}"
+	echo "If you have spec.mysql.autoRecovery disabled, wait for all pods to be up and running and connect to one of them using mysql-shell:"
+	echo "kubectl -n ${namespace} exec -it $(hostname) -- mysqlsh root:<password>@localhost"
+	echo "and run the following command to reboot cluster:"
+	echo "dba.rebootClusterFromCompleteOutage()"
+	echo "and delete /var/lib/mysql/full-cluster-crash file in each pod."
 	echo "######FULL_CLUSTER_CRASH:${node_name}######"
 
 	ensure_read_only

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -9,6 +9,11 @@ import (
 	"github.com/percona/percona-server-mysql-operator/pkg/mysql"
 )
 
+const (
+	fullClusterCrashFile = "/var/lib/mysql/full-cluster-crash"
+	manualRecoveryFile   = "/var/lib/mysql/sleep-forever"
+)
+
 func main() {
 	f, err := os.OpenFile(filepath.Join(mysql.DataMountPath, "bootstrap.log"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
@@ -17,6 +22,18 @@ func main() {
 	defer f.Close()
 	log.SetOutput(f)
 
+	fullClusterCrash, err := fileExists(fullClusterCrashFile)
+	if err == nil && fullClusterCrash {
+		log.Printf("%s exists. exiting...", fullClusterCrashFile)
+		os.Exit(0)
+	}
+
+	manualRecovery, err := fileExists(manualRecoveryFile)
+	if err == nil && manualRecovery {
+		log.Printf("%s exists. exiting...", manualRecoveryFile)
+		os.Exit(0)
+	}
+
 	clusterType := os.Getenv("CLUSTER_TYPE")
 	switch clusterType {
 	case "group-replication":
@@ -24,7 +41,7 @@ func main() {
 			log.Fatalf("bootstrap failed: %v", err)
 		}
 	case "async":
-		if err := bootstrapAsyncReplication(); err != nil {
+		if err := bootstrapAsyncReplication(context.Background()); err != nil {
 			log.Fatalf("bootstrap failed: %v", err)
 		}
 	default:

--- a/cmd/bootstrap/utils.go
+++ b/cmd/bootstrap/utils.go
@@ -95,3 +95,17 @@ func waitLockRemoval() error {
 		}
 	}
 }
+
+func createFile(name, content string) error {
+	f, err := os.Create(name)
+	if err != nil {
+		return errors.Wrapf(err, "create %s", name)
+	}
+
+	_, err = f.WriteString(content)
+	if err != nil {
+		return errors.Wrapf(err, "write to %s", name)
+	}
+
+	return nil
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -117,6 +117,7 @@ func main() {
 		Client:        nsClient,
 		Scheme:        mgr.GetScheme(),
 		ServerVersion: serverVersion,
+		Recorder:      mgr.GetEventRecorderFor("ps-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ps-controller")
 		os.Exit(1)

--- a/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
+++ b/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
@@ -1293,6 +1293,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  autoRecovery:
+                    type: boolean
                   clusterType:
                     type: string
                   configuration:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -8491,6 +8491,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -2905,6 +2905,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  autoRecovery:
+                    type: boolean
                   clusterType:
                     type: string
                   configuration:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -14,7 +14,7 @@ spec:
   upgradeOptions:
     versionServiceEndpoint: https://check.percona.com
     apply: disabled
-  initImage: perconalab/percona-server-mysql-operator:main
+#  initImage: perconalab/percona-server-mysql-operator:main
 #  ignoreAnnotations:
 #    - service.beta.kubernetes.io/aws-load-balancer-backend-protocol
 #  ignoreLabels:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -31,6 +31,7 @@ spec:
 
   mysql:
     clusterType: group-replication
+    autoRecovery: true
     image: perconalab/percona-server-mysql-operator:main-psmysql
     imagePullPolicy: Always
 #    initImage: percona/percona-server-mysql-operator:0.5.0

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -2905,6 +2905,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  autoRecovery:
+                    type: boolean
                   clusterType:
                     type: string
                   configuration:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -70,6 +70,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/e2e-tests/tests/limits/01-assert.yaml
+++ b/e2e-tests/tests/limits/01-assert.yaml
@@ -78,7 +78,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 30
+          timeoutSeconds: 10
         name: mysql
         ports:
         - containerPort: 3306

--- a/e2e-tests/tests/limits/03-assert.yaml
+++ b/e2e-tests/tests/limits/03-assert.yaml
@@ -78,7 +78,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 30
+          timeoutSeconds: 10
         name: mysql
         ports:
         - containerPort: 3306

--- a/e2e-tests/tests/limits/05-assert.yaml
+++ b/e2e-tests/tests/limits/05-assert.yaml
@@ -78,7 +78,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 30
+          timeoutSeconds: 10
         name: mysql
         ports:
         - containerPort: 3306

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ps
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"encoding/json"
@@ -37,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	k8sretry "k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,6 +46,7 @@ import (
 
 	"github.com/percona/percona-server-mysql-operator/api/v1alpha1"
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
+	"github.com/percona/percona-server-mysql-operator/pkg/clientcmd"
 	"github.com/percona/percona-server-mysql-operator/pkg/controller/psrestore"
 	"github.com/percona/percona-server-mysql-operator/pkg/haproxy"
 	"github.com/percona/percona-server-mysql-operator/pkg/innodbcluster"
@@ -62,10 +65,12 @@ type PerconaServerMySQLReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
 	ServerVersion *platform.ServerVersion
+	Recorder      record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqls;perconaservermysqls/status;perconaservermysqls/finalizers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods;pods/exec;configmaps;services;secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets;deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=certmanager.k8s.io;cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete;deletecollection
 
@@ -221,7 +226,7 @@ func (r *PerconaServerMySQLReconciler) deleteMySQLPods(ctx context.Context, cr *
 
 			podFQDN := fmt.Sprintf("%s.%s.%s", pod.Name, mysql.ServiceName(cr), cr.Namespace)
 
-			state, err := db.GetMemberState(podFQDN)
+			state, err := db.GetMemberState(ctx, podFQDN)
 			if err != nil {
 				return errors.Wrapf(err, "get member state of %s from performance_schema", pod.Name)
 			}
@@ -335,6 +340,9 @@ func (r *PerconaServerMySQLReconciler) doReconcile(
 ) error {
 	log := logf.FromContext(ctx).WithName("doReconcile")
 
+	if err := r.reconcileFullClusterCrash(ctx, cr); err != nil {
+		return errors.Wrap(err, "failed to check full cluster crash")
+	}
 	if err := r.reconcileVersions(ctx, cr); err != nil {
 		log.Error(err, "failed to reconcile versions")
 	}
@@ -1182,6 +1190,38 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 		cr.Status.State = cr.Status.MySQL.State
 	}
 
+	if cr.Spec.MySQL.IsGR() {
+		cli, err := clientcmd.NewClient()
+		if err != nil {
+			return err
+		}
+
+		pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr))
+		if err != nil {
+			return errors.Wrap(err, "get pods")
+		}
+
+		var outb, errb bytes.Buffer
+		cmd := []string{"/bin/bash", "-c", "cat /var/lib/mysql/full-cluster-crash"}
+		fullClusterCrash := false
+		for _, pod := range pods {
+			err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)
+			if err != nil {
+				if strings.Contains(errb.String(), "No such file or directory") {
+					continue
+				}
+				return errors.Wrapf(err, "run %s, stdout: %s, stderr: %s", cmd, outb.String(), errb.String())
+			}
+
+			fullClusterCrash = true
+		}
+
+		if fullClusterCrash {
+			cr.Status.State = apiv1alpha1.StateError
+			r.Recorder.Event(cr, "Warning", "FullClusterCrashDetected", "Full cluster crash detected")
+		}
+	}
+
 	cr.Status.Host, err = appHost(ctx, r.Client, cr)
 	if err != nil {
 		return errors.Wrap(err, "get app host")
@@ -1352,7 +1392,7 @@ func (r *PerconaServerMySQLReconciler) getPrimaryFromGR(ctx context.Context, cr 
 		return "", errors.Wrapf(err, "open connection to %s", fqdn)
 	}
 
-	return db.GetGroupReplicationPrimary()
+	return db.GetGroupReplicationPrimary(ctx)
 }
 
 func (r *PerconaServerMySQLReconciler) getPrimaryHost(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) (string, error) {
@@ -1407,14 +1447,14 @@ func (r *PerconaServerMySQLReconciler) stopAsyncReplication(ctx context.Context,
 				return errors.Wrapf(err, "stop replica %s", hostname)
 			}
 
-			status, _, err := repDb.ReplicationStatus()
+			status, _, err := repDb.ReplicationStatus(ctx)
 			if err != nil {
 				return errors.Wrapf(err, "get replication status of %s", hostname)
 			}
 
 			for status == replicator.ReplicationStatusActive {
 				time.Sleep(250 * time.Millisecond)
-				status, _, err = repDb.ReplicationStatus()
+				status, _, err = repDb.ReplicationStatus(ctx)
 				if err != nil {
 					return errors.Wrapf(err, "get replication status of %s", hostname)
 				}
@@ -1462,7 +1502,7 @@ func (r *PerconaServerMySQLReconciler) startAsyncReplication(ctx context.Context
 			defer db.Close()
 
 			log.V(1).Info("Change replication source", "primary", primary.Key.Hostname, "replica", hostname)
-			if err := db.ChangeReplicationSource(primary.Key.Hostname, replicaPass, primary.Key.Port); err != nil {
+			if err := db.ChangeReplicationSource(ctx, primary.Key.Hostname, replicaPass, primary.Key.Port); err != nil {
 				return errors.Wrapf(err, "change replication source on %s", hostname)
 			}
 
@@ -1498,7 +1538,7 @@ func (r *PerconaServerMySQLReconciler) restartGroupReplication(ctx context.Conte
 	}
 	defer db.Close()
 
-	replicas, err := db.GetGroupReplicationReplicas()
+	replicas, err := db.GetGroupReplicationReplicas(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get replicas")
 	}
@@ -1519,23 +1559,23 @@ func (r *PerconaServerMySQLReconciler) restartGroupReplication(ctx context.Conte
 		}
 		defer db.Close()
 
-		if err := db.StopGroupReplication(); err != nil {
+		if err := db.StopGroupReplication(ctx); err != nil {
 			return errors.Wrapf(err, "stop group replication on %s", host)
 		}
 		log.V(1).Info("Stopped group replication", "hostname", host)
 
-		if err := db.ChangeGroupReplicationPassword(replicaPass); err != nil {
+		if err := db.ChangeGroupReplicationPassword(ctx, replicaPass); err != nil {
 			return errors.Wrapf(err, "change group replication password on %s", host)
 		}
 		log.V(1).Info("Changed group replication password", "hostname", host)
 
-		if err := db.StartGroupReplication(replicaPass); err != nil {
+		if err := db.StartGroupReplication(ctx, replicaPass); err != nil {
 			return errors.Wrapf(err, "start group replication on %s", host)
 		}
 		log.V(1).Info("Started group replication", "hostname", host)
 	}
 
-	primary, err := db.GetGroupReplicationPrimary()
+	primary, err := db.GetGroupReplicationPrimary(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get primary member")
 	}
@@ -1555,17 +1595,17 @@ func (r *PerconaServerMySQLReconciler) restartGroupReplication(ctx context.Conte
 	}
 	defer db.Close()
 
-	if err := db.StopGroupReplication(); err != nil {
+	if err := db.StopGroupReplication(ctx); err != nil {
 		return errors.Wrapf(err, "stop group replication on %s", primary)
 	}
 	log.V(1).Info("Stopped group replication", "hostname", primary)
 
-	if err := db.ChangeGroupReplicationPassword(replicaPass); err != nil {
+	if err := db.ChangeGroupReplicationPassword(ctx, replicaPass); err != nil {
 		return errors.Wrapf(err, "change group replication password on %s", primary)
 	}
 	log.V(1).Info("Changed group replication password", "hostname", primary)
 
-	if err := db.StartGroupReplication(replicaPass); err != nil {
+	if err := db.StartGroupReplication(ctx, replicaPass); err != nil {
 		return errors.Wrapf(err, "start group replication on %s", primary)
 	}
 	log.V(1).Info("Started group replication", "hostname", primary)

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -1202,7 +1202,7 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 		}
 
 		var outb, errb bytes.Buffer
-		cmd := []string{"/bin/bash", "-c", "cat /var/lib/mysql/full-cluster-crash"}
+		cmd := []string{"cat", "/var/lib/mysql/full-cluster-crash"}
 		fullClusterCrash := false
 		for _, pod := range pods {
 			err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)

--- a/pkg/controller/ps/crash_recovery.go
+++ b/pkg/controller/ps/crash_recovery.go
@@ -61,7 +61,10 @@ func (r *PerconaServerMySQLReconciler) reconcileFullClusterCrash(ctx context.Con
 		log.Info("Pod is waiting for recovery", "pod", pod.Name, "gtidExecuted", outb.String())
 
 		if !cr.Spec.MySQL.AutoRecovery {
-			log.Info("Full cluster crash detected but auto recovery is not enabled. Enable .spec.mysql.autoRecovery or recover cluster manually.")
+			log.Error(nil, `
+			Full cluster crash detected but auto recovery is not enabled.
+			Enable .spec.mysql.autoRecovery or recover cluster manually
+			(connect to one of the pods using mysql-shell and run 'dba.rebootClusterFromCompleteOutage() and delete /var/lib/mysql/full-cluster-crash in each pod.').`)
 			continue
 		}
 

--- a/pkg/controller/ps/crash_recovery.go
+++ b/pkg/controller/ps/crash_recovery.go
@@ -1,0 +1,112 @@
+package ps
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
+	"github.com/percona/percona-server-mysql-operator/pkg/clientcmd"
+	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
+	"github.com/percona/percona-server-mysql-operator/pkg/mysql"
+	"github.com/percona/percona-server-mysql-operator/pkg/mysqlsh"
+)
+
+func (r *PerconaServerMySQLReconciler) reconcileFullClusterCrash(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
+	log := logf.FromContext(ctx).WithName("Crash recovery")
+
+	cli, err := clientcmd.NewClient()
+	if err != nil {
+		return err
+	}
+
+	pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr))
+	if err != nil {
+		return errors.Wrap(err, "get pods")
+	}
+
+	if len(pods) < int(cr.MySQLSpec().Size) {
+		return nil
+	}
+
+	// we need every pod to be ready to reboot
+	for _, pod := range pods {
+		if !k8s.IsPodReady(pod) {
+			return nil
+		}
+	}
+
+	operatorPass, err := k8s.UserPassword(ctx, r.Client, cr, apiv1alpha1.UserOperator)
+	if err != nil {
+		return errors.Wrap(err, "get operator password")
+	}
+
+	var outb, errb bytes.Buffer
+	cmd := []string{"/bin/bash", "-c", "cat /var/lib/mysql/full-cluster-crash"}
+
+	for _, pod := range pods {
+		err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)
+		if err != nil {
+			if strings.Contains(errb.String(), "No such file or directory") {
+				continue
+			}
+			return errors.Wrapf(err, "run %s, stdout: %s, stderr: %s", cmd, outb.String(), errb.String())
+		}
+
+		log.Info("Pod is waiting for recovery", "pod", pod.Name, "gtidExecuted", outb.String())
+
+		podFQDN := fmt.Sprintf("%s.%s.%s", pod.Name, mysql.ServiceName(cr), cr.Namespace)
+		podUri := fmt.Sprintf("%s:%s@%s", apiv1alpha1.UserOperator, operatorPass, podFQDN)
+
+		mysh, err := mysqlsh.NewWithExec(&pod, podUri)
+		if err != nil {
+			return err
+		}
+
+		err = mysh.RebootClusterFromCompleteOutageWithExec(ctx, cr.InnoDBClusterName())
+		if err == nil {
+			log.Info("Cluster was successfully rebooted")
+			r.Recorder.Event(cr, "Normal", "FullClusterCrashRecovered", "Cluster recovered from full cluster crash")
+			err := r.cleanupFullClusterCrashFile(ctx, cr)
+			if err != nil {
+				log.Error(err, "failed to remove /var/lib/mysql/full-cluster-crash")
+			}
+			break
+		}
+	}
+
+	return nil
+}
+
+func (r *PerconaServerMySQLReconciler) cleanupFullClusterCrashFile(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL) error {
+	log := logf.FromContext(ctx)
+
+	cli, err := clientcmd.NewClient()
+	if err != nil {
+		return err
+	}
+
+	pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr))
+	if err != nil {
+		return errors.Wrap(err, "get pods")
+	}
+
+	var outb, errb bytes.Buffer
+	cmd := []string{"/bin/bash", "-c", "rm /var/lib/mysql/full-cluster-crash"}
+	for _, pod := range pods {
+		err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)
+		if err != nil {
+			if strings.Contains(errb.String(), "No such file or directory") {
+				continue
+			}
+			return errors.Wrapf(err, "run %s, stdout: %s, stderr: %s", cmd, outb.String(), errb.String())
+		}
+		log.V(1).Info("Removed /var/lib/mysql/full-cluster-crash", "pod", pod.Name)
+	}
+
+	return nil
+}

--- a/pkg/controller/ps/crash_recovery.go
+++ b/pkg/controller/ps/crash_recovery.go
@@ -46,7 +46,7 @@ func (r *PerconaServerMySQLReconciler) reconcileFullClusterCrash(ctx context.Con
 	}
 
 	var outb, errb bytes.Buffer
-	cmd := []string{"/bin/bash", "-c", "cat /var/lib/mysql/full-cluster-crash"}
+	cmd := []string{"cat", "/var/lib/mysql/full-cluster-crash"}
 
 	for _, pod := range pods {
 		err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)
@@ -96,7 +96,7 @@ func (r *PerconaServerMySQLReconciler) cleanupFullClusterCrashFile(ctx context.C
 	}
 
 	var outb, errb bytes.Buffer
-	cmd := []string{"/bin/bash", "-c", "rm /var/lib/mysql/full-cluster-crash"}
+	cmd := []string{"rm", "/var/lib/mysql/full-cluster-crash"}
 	for _, pod := range pods {
 		err = cli.Exec(ctx, &pod, "mysql", cmd, nil, &outb, &errb, false)
 		if err != nil {

--- a/pkg/controller/ps/crash_recovery.go
+++ b/pkg/controller/ps/crash_recovery.go
@@ -59,6 +59,11 @@ func (r *PerconaServerMySQLReconciler) reconcileFullClusterCrash(ctx context.Con
 
 		log.Info("Pod is waiting for recovery", "pod", pod.Name, "gtidExecuted", outb.String())
 
+		if !cr.Spec.MySQL.AutoRecovery {
+			log.Info("Full cluster crash detected but auto recovery is not enabled. Enable .spec.mysql.autoRecovery or recover cluster manually.")
+			continue
+		}
+
 		podFQDN := fmt.Sprintf("%s.%s.%s", pod.Name, mysql.ServiceName(cr), cr.Namespace)
 		podUri := fmt.Sprintf("%s:%s@%s", apiv1alpha1.UserOperator, operatorPass, podFQDN)
 

--- a/pkg/mysqlsh/mysqlshexec.go
+++ b/pkg/mysqlsh/mysqlshexec.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -173,12 +172,8 @@ func (m *mysqlshExec) TopologyWithExec(ctx context.Context, clusterName string) 
 	return status.DefaultReplicaSet.Topology, nil
 }
 
-func (m *mysqlshExec) RebootClusterFromCompleteOutageWithExec(ctx context.Context, clusterName string, rejoinInstances []string) error {
-	cmd := fmt.Sprintf(
-		"dba.rebootClusterFromCompleteOutage('%s', {rejoinInstances: ['%s'], removeInstances: []})",
-		clusterName,
-		strings.Join(rejoinInstances, ","),
-	)
+func (m *mysqlshExec) RebootClusterFromCompleteOutageWithExec(ctx context.Context, clusterName string) error {
+	cmd := fmt.Sprintf("dba.rebootClusterFromCompleteOutage('%s')", clusterName)
 
 	if err := m.runWithExec(ctx, cmd); err != nil {
 		return errors.Wrap(err, "reboot cluster from complete outage")

--- a/pkg/replicator/replicator.go
+++ b/pkg/replicator/replicator.go
@@ -1,6 +1,7 @@
 package replicator
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
+	"github.com/percona/percona-server-mysql-operator/pkg/innodbcluster"
 )
 
 const DefaultChannelName = ""
@@ -35,36 +37,37 @@ const (
 var ErrGroupReplicationNotReady = errors.New("Error 3092: The server is not configured properly to be an active member of the group.")
 
 type Replicator interface {
-	ChangeReplicationSource(host, replicaPass string, port int32) error
-	StartReplication(host, replicaPass string, port int32) error
-	StopReplication() error
-	ResetReplication() error
-	ReplicationStatus() (ReplicationStatus, string, error)
-	EnableSuperReadonly() error
-	IsReadonly() (bool, error)
-	ReportHost() (string, error)
+	ChangeReplicationSource(ctx context.Context, host, replicaPass string, port int32) error
+	StartReplication(ctx context.Context, host, replicaPass string, port int32) error
+	StopReplication(ctx context.Context) error
+	ResetReplication(ctx context.Context) error
+	ReplicationStatus(ctx context.Context) (ReplicationStatus, string, error)
+	EnableSuperReadonly(ctx context.Context) error
+	IsReadonly(ctx context.Context) (bool, error)
+	ReportHost(ctx context.Context) (string, error)
 	Close() error
-	CloneInProgress() (bool, error)
-	NeedsClone(donor string, port int32) (bool, error)
-	Clone(donor, user, pass string, port int32) error
-	IsReplica() (bool, error)
-	DumbQuery() error
-	GetGlobal(variable string) (interface{}, error)
-	SetGlobal(variable, value interface{}) error
-	ChangeGroupReplicationPassword(replicaPass string) error
-	StartGroupReplication(password string) error
-	StopGroupReplication() error
-	GetGroupReplicationPrimary() (string, error)
-	GetGroupReplicationReplicas() ([]string, error)
-	GetMemberState(host string) (MemberState, error)
-	GetGroupReplicationMembers() ([]string, error)
-	CheckIfDatabaseExists(name string) (bool, error)
-	CheckIfInPrimaryPartition() (bool, error)
+	CloneInProgress(ctx context.Context) (bool, error)
+	NeedsClone(ctx context.Context, donor string, port int32) (bool, error)
+	Clone(ctx context.Context, donor, user, pass string, port int32) error
+	IsReplica(ctx context.Context) (bool, error)
+	DumbQuery(ctx context.Context) error
+	GetGlobal(ctx context.Context, variable string) (interface{}, error)
+	SetGlobal(ctx context.Context, variable, value interface{}) error
+	ChangeGroupReplicationPassword(ctx context.Context, replicaPass string) error
+	StartGroupReplication(ctx context.Context, password string) error
+	StopGroupReplication(ctx context.Context) error
+	GetGroupReplicationPrimary(ctx context.Context) (string, error)
+	GetGroupReplicationReplicas(ctx context.Context) ([]string, error)
+	GetMemberState(ctx context.Context, host string) (MemberState, error)
+	GetGroupReplicationMembers(ctx context.Context) ([]string, error)
+	CheckIfDatabaseExists(ctx context.Context, name string) (bool, error)
+	CheckIfInPrimaryPartition(ctx context.Context) (bool, error)
+	CheckIfPrimaryUnreachable(ctx context.Context) (bool, error)
 }
 
 type dbImpl struct{ db *sql.DB }
 
-func NewReplicator(user apiv1alpha1.SystemUser, pass, host string, port int32) (Replicator, error) {
+func NewReplicator(ctx context.Context, user apiv1alpha1.SystemUser, pass, host string, port int32) (Replicator, error) {
 	config := mysql.NewConfig()
 
 	config.User = string(user)
@@ -74,9 +77,9 @@ func NewReplicator(user apiv1alpha1.SystemUser, pass, host string, port int32) (
 	config.DBName = "performance_schema"
 	config.Params = map[string]string{
 		"interpolateParams": "true",
-		"timeout":           "20s",
-		"readTimeout":       "20s",
-		"writeTimeout":      "20s",
+		"timeout":           "10s",
+		"readTimeout":       "10s",
+		"writeTimeout":      "10s",
 		"tls":               "preferred",
 	}
 
@@ -85,16 +88,16 @@ func NewReplicator(user apiv1alpha1.SystemUser, pass, host string, port int32) (
 		return nil, errors.Wrap(err, "connect to MySQL")
 	}
 
-	if err := db.Ping(); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		return nil, errors.Wrap(err, "ping database")
 	}
 
 	return &dbImpl{db}, nil
 }
 
-func (d *dbImpl) ChangeReplicationSource(host, replicaPass string, port int32) error {
+func (d *dbImpl) ChangeReplicationSource(ctx context.Context, host, replicaPass string, port int32) error {
 	// TODO: Make retries configurable
-	_, err := d.db.Exec(`
+	_, err := d.db.ExecContext(ctx, `
             CHANGE REPLICATION SOURCE TO
                 SOURCE_USER=?,
                 SOURCE_PASSWORD=?,
@@ -113,27 +116,27 @@ func (d *dbImpl) ChangeReplicationSource(host, replicaPass string, port int32) e
 	return nil
 }
 
-func (d *dbImpl) StartReplication(host, replicaPass string, port int32) error {
-	if err := d.ChangeReplicationSource(host, replicaPass, port); err != nil {
+func (d *dbImpl) StartReplication(ctx context.Context, host, replicaPass string, port int32) error {
+	if err := d.ChangeReplicationSource(ctx, host, replicaPass, port); err != nil {
 		return errors.Wrap(err, "change replication source")
 	}
 
-	_, err := d.db.Exec("START REPLICA")
+	_, err := d.db.ExecContext(ctx, "START REPLICA")
 	return errors.Wrap(err, "start replication")
 }
 
-func (d *dbImpl) StopReplication() error {
-	_, err := d.db.Exec("STOP REPLICA")
+func (d *dbImpl) StopReplication(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "STOP REPLICA")
 	return errors.Wrap(err, "stop replication")
 }
 
-func (d *dbImpl) ResetReplication() error {
-	_, err := d.db.Exec("RESET REPLICA ALL")
+func (d *dbImpl) ResetReplication(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "RESET REPLICA ALL")
 	return errors.Wrap(err, "reset replication")
 }
 
-func (d *dbImpl) ReplicationStatus() (ReplicationStatus, string, error) {
-	row := d.db.QueryRow(`
+func (d *dbImpl) ReplicationStatus(ctx context.Context) (ReplicationStatus, string, error) {
+	row := d.db.QueryRowContext(ctx, `
         SELECT
 	    connection_status.SERVICE_STATE,
 	    applier_status.SERVICE_STATE,
@@ -161,25 +164,25 @@ func (d *dbImpl) ReplicationStatus() (ReplicationStatus, string, error) {
 	return ReplicationStatusNotInitiated, "", nil
 }
 
-func (d *dbImpl) IsReplica() (bool, error) {
-	status, _, err := d.ReplicationStatus()
+func (d *dbImpl) IsReplica(ctx context.Context) (bool, error) {
+	status, _, err := d.ReplicationStatus(ctx)
 	return status == ReplicationStatusActive, errors.Wrap(err, "get replication status")
 }
 
-func (d *dbImpl) EnableSuperReadonly() error {
-	_, err := d.db.Exec("SET GLOBAL SUPER_READ_ONLY=1")
+func (d *dbImpl) EnableSuperReadonly(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "SET GLOBAL SUPER_READ_ONLY=1")
 	return errors.Wrap(err, "set global super_read_only param to 1")
 }
 
-func (d *dbImpl) IsReadonly() (bool, error) {
+func (d *dbImpl) IsReadonly(ctx context.Context) (bool, error) {
 	var readonly int
-	err := d.db.QueryRow("select @@read_only and @@super_read_only").Scan(&readonly)
+	err := d.db.QueryRowContext(ctx, "select @@read_only and @@super_read_only").Scan(&readonly)
 	return readonly == 1, errors.Wrap(err, "select global read_only param")
 }
 
-func (d *dbImpl) ReportHost() (string, error) {
+func (d *dbImpl) ReportHost(ctx context.Context) (string, error) {
 	var reportHost string
-	err := d.db.QueryRow("select @@report_host").Scan(&reportHost)
+	err := d.db.QueryRowContext(ctx, "select @@report_host").Scan(&reportHost)
 	return reportHost, errors.Wrap(err, "select report_host param")
 }
 
@@ -187,8 +190,8 @@ func (d *dbImpl) Close() error {
 	return d.db.Close()
 }
 
-func (d *dbImpl) CloneInProgress() (bool, error) {
-	rows, err := d.db.Query("SELECT STATE FROM clone_status")
+func (d *dbImpl) CloneInProgress(ctx context.Context) (bool, error) {
+	rows, err := d.db.QueryContext(ctx, "SELECT STATE FROM clone_status")
 	if err != nil {
 		return false, errors.Wrap(err, "fetch clone status")
 	}
@@ -208,8 +211,8 @@ func (d *dbImpl) CloneInProgress() (bool, error) {
 	return false, nil
 }
 
-func (d *dbImpl) NeedsClone(donor string, port int32) (bool, error) {
-	rows, err := d.db.Query("SELECT SOURCE, STATE FROM clone_status")
+func (d *dbImpl) NeedsClone(ctx context.Context, donor string, port int32) (bool, error) {
+	rows, err := d.db.QueryContext(ctx, "SELECT SOURCE, STATE FROM clone_status")
 	if err != nil {
 		return false, errors.Wrap(err, "fetch clone status")
 	}
@@ -228,13 +231,13 @@ func (d *dbImpl) NeedsClone(donor string, port int32) (bool, error) {
 	return true, nil
 }
 
-func (d *dbImpl) Clone(donor, user, pass string, port int32) error {
-	_, err := d.db.Exec("SET GLOBAL clone_valid_donor_list=?", fmt.Sprintf("%s:%d", donor, port))
+func (d *dbImpl) Clone(ctx context.Context, donor, user, pass string, port int32) error {
+	_, err := d.db.ExecContext(ctx, "SET GLOBAL clone_valid_donor_list=?", fmt.Sprintf("%s:%d", donor, port))
 	if err != nil {
 		return errors.Wrap(err, "set clone_valid_donor_list")
 	}
 
-	_, err = d.db.Exec("CLONE INSTANCE FROM ?@?:? IDENTIFIED BY ?", user, donor, port, pass)
+	_, err = d.db.ExecContext(ctx, "CLONE INSTANCE FROM ?@?:? IDENTIFIED BY ?", user, donor, port, pass)
 
 	mErr, ok := err.(*mysql.MySQLError)
 	if !ok {
@@ -249,25 +252,25 @@ func (d *dbImpl) Clone(donor, user, pass string, port int32) error {
 	return nil
 }
 
-func (d *dbImpl) DumbQuery() error {
-	_, err := d.db.Exec("SELECT 1")
+func (d *dbImpl) DumbQuery(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "SELECT 1")
 	return errors.Wrap(err, "SELECT 1")
 }
 
-func (d *dbImpl) GetGlobal(variable string) (interface{}, error) {
+func (d *dbImpl) GetGlobal(ctx context.Context, variable string) (interface{}, error) {
 	// TODO: check how to do this without being vulnerable to injection
 	var value interface{}
-	err := d.db.QueryRow(fmt.Sprintf("SELECT @@%s", variable)).Scan(&value)
+	err := d.db.QueryRowContext(ctx, fmt.Sprintf("SELECT @@%s", variable)).Scan(&value)
 	return value, errors.Wrapf(err, "SELECT @@%s", variable)
 }
 
-func (d *dbImpl) SetGlobal(variable, value interface{}) error {
-	_, err := d.db.Exec(fmt.Sprintf("SET GLOBAL %s=?", variable), value)
+func (d *dbImpl) SetGlobal(ctx context.Context, variable, value interface{}) error {
+	_, err := d.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=?", variable), value)
 	return errors.Wrapf(err, "SET GLOBAL %s=%s", variable, value)
 }
 
-func (d *dbImpl) StartGroupReplication(password string) error {
-	_, err := d.db.Exec("START GROUP_REPLICATION USER=?, PASSWORD=?", apiv1alpha1.UserReplication, password)
+func (d *dbImpl) StartGroupReplication(ctx context.Context, password string) error {
+	_, err := d.db.ExecContext(ctx, "START GROUP_REPLICATION USER=?, PASSWORD=?", apiv1alpha1.UserReplication, password)
 
 	mErr, ok := err.(*mysql.MySQLError)
 	if !ok {
@@ -282,13 +285,13 @@ func (d *dbImpl) StartGroupReplication(password string) error {
 	return errors.Wrap(err, "start group replication")
 }
 
-func (d *dbImpl) StopGroupReplication() error {
-	_, err := d.db.Exec("STOP GROUP_REPLICATION")
+func (d *dbImpl) StopGroupReplication(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "STOP GROUP_REPLICATION")
 	return errors.Wrap(err, "stop group replication")
 }
 
-func (d *dbImpl) ChangeGroupReplicationPassword(replicaPass string) error {
-	_, err := d.db.Exec(`
+func (d *dbImpl) ChangeGroupReplicationPassword(ctx context.Context, replicaPass string) error {
+	_, err := d.db.ExecContext(ctx, `
             CHANGE REPLICATION SOURCE TO
                 SOURCE_USER=?,
                 SOURCE_PASSWORD=?
@@ -301,10 +304,10 @@ func (d *dbImpl) ChangeGroupReplicationPassword(replicaPass string) error {
 	return nil
 }
 
-func (d *dbImpl) GetGroupReplicationPrimary() (string, error) {
+func (d *dbImpl) GetGroupReplicationPrimary(ctx context.Context) (string, error) {
 	var host string
 
-	err := d.db.QueryRow("SELECT MEMBER_HOST FROM replication_group_members WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE'").Scan(&host)
+	err := d.db.QueryRowContext(ctx, "SELECT MEMBER_HOST FROM replication_group_members WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE'").Scan(&host)
 	if err != nil {
 		return "", errors.Wrap(err, "query primary member")
 	}
@@ -312,10 +315,10 @@ func (d *dbImpl) GetGroupReplicationPrimary() (string, error) {
 	return host, nil
 }
 
-func (d *dbImpl) GetGroupReplicationReplicas() ([]string, error) {
+func (d *dbImpl) GetGroupReplicationReplicas(ctx context.Context) ([]string, error) {
 	replicas := make([]string, 0)
 
-	rows, err := d.db.Query("SELECT MEMBER_HOST FROM replication_group_members WHERE MEMBER_ROLE='SECONDARY' AND MEMBER_STATE='ONLINE'")
+	rows, err := d.db.QueryContext(ctx, "SELECT MEMBER_HOST FROM replication_group_members WHERE MEMBER_ROLE='SECONDARY' AND MEMBER_STATE='ONLINE'")
 	if err != nil {
 		return nil, errors.Wrap(err, "query replicas")
 	}
@@ -333,10 +336,10 @@ func (d *dbImpl) GetGroupReplicationReplicas() ([]string, error) {
 	return replicas, nil
 }
 
-func (d *dbImpl) GetMemberState(host string) (MemberState, error) {
+func (d *dbImpl) GetMemberState(ctx context.Context, host string) (MemberState, error) {
 	var state MemberState
 
-	err := d.db.QueryRow("SELECT MEMBER_STATE FROM replication_group_members WHERE MEMBER_HOST=?", host).Scan(&state)
+	err := d.db.QueryRowContext(ctx, "SELECT MEMBER_STATE FROM replication_group_members WHERE MEMBER_HOST=?", host).Scan(&state)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return MemberStateOffline, nil
@@ -347,10 +350,10 @@ func (d *dbImpl) GetMemberState(host string) (MemberState, error) {
 	return state, nil
 }
 
-func (d *dbImpl) GetGroupReplicationMembers() ([]string, error) {
+func (d *dbImpl) GetGroupReplicationMembers(ctx context.Context) ([]string, error) {
 	members := make([]string, 0)
 
-	rows, err := d.db.Query("SELECT MEMBER_HOST FROM replication_group_members")
+	rows, err := d.db.QueryContext(ctx, "SELECT MEMBER_HOST FROM replication_group_members")
 	if err != nil {
 		return nil, errors.Wrap(err, "query members")
 	}
@@ -368,10 +371,10 @@ func (d *dbImpl) GetGroupReplicationMembers() ([]string, error) {
 	return members, nil
 }
 
-func (d *dbImpl) CheckIfDatabaseExists(name string) (bool, error) {
+func (d *dbImpl) CheckIfDatabaseExists(ctx context.Context, name string) (bool, error) {
 	var db string
 
-	err := d.db.QueryRow("SHOW DATABASES LIKE ?", name).Scan(&db)
+	err := d.db.QueryRowContext(ctx, "SHOW DATABASES LIKE ?", name).Scan(&db)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -382,10 +385,10 @@ func (d *dbImpl) CheckIfDatabaseExists(name string) (bool, error) {
 	return true, nil
 }
 
-func (d *dbImpl) CheckIfInPrimaryPartition() (bool, error) {
+func (d *dbImpl) CheckIfInPrimaryPartition(ctx context.Context) (bool, error) {
 	var in bool
 
-	err := d.db.QueryRow(`
+	err := d.db.QueryRowContext(ctx, `
 	SELECT
 		MEMBER_STATE = 'ONLINE'
 		AND (
@@ -416,4 +419,22 @@ func (d *dbImpl) CheckIfInPrimaryPartition() (bool, error) {
 	}
 
 	return in, nil
+}
+
+func (d *dbImpl) CheckIfPrimaryUnreachable(ctx context.Context) (bool, error) {
+	var state string
+
+	err := d.db.QueryRowContext(ctx, `
+	SELECT
+		MEMBER_STATE
+	FROM
+		performance_schema.replication_group_members
+	WHERE
+		MEMBER_ROLE = 'PRIMARY'
+	`).Scan(&state)
+	if err != nil {
+		return false, err
+	}
+
+	return state == string(innodbcluster.MemberStateUnreachable), nil
 }

--- a/pkg/replicator/replicatorexec.go
+++ b/pkg/replicator/replicatorexec.go
@@ -16,6 +16,7 @@ import (
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
 	"github.com/percona/percona-server-mysql-operator/pkg/clientcmd"
+	"github.com/percona/percona-server-mysql-operator/pkg/innodbcluster"
 )
 
 var sensitiveRegexp = regexp.MustCompile(":.*@")
@@ -37,10 +38,10 @@ func NewReplicatorExec(pod *corev1.Pod, user apiv1alpha1.SystemUser, pass, host 
 	return &dbImplExec{client: c, pod: pod, user: user, pass: pass, host: host}, nil
 }
 
-func (d *dbImplExec) exec(stm string, stdout, stderr *bytes.Buffer) error {
+func (d *dbImplExec) exec(ctx context.Context, stm string, stdout, stderr *bytes.Buffer) error {
 	cmd := []string{"mysql", "--database", "performance_schema", fmt.Sprintf("-p%s", d.pass), "-u", string(d.user), "-h", d.host, "-e", stm}
 
-	err := d.client.Exec(context.TODO(), d.pod, "mysql", cmd, nil, stdout, stderr, false)
+	err := d.client.Exec(ctx, d.pod, "mysql", cmd, nil, stdout, stderr, false)
 	if err != nil {
 		sout := sensitiveRegexp.ReplaceAllString(stdout.String(), ":*****@")
 		serr := sensitiveRegexp.ReplaceAllString(stderr.String(), ":*****@")
@@ -54,9 +55,9 @@ func (d *dbImplExec) exec(stm string, stdout, stderr *bytes.Buffer) error {
 	return nil
 }
 
-func (d *dbImplExec) query(query string, out interface{}) error {
+func (d *dbImplExec) query(ctx context.Context, query string, out interface{}) error {
 	var errb, outb bytes.Buffer
-	err := d.exec(query, &outb, &errb)
+	err := d.exec(ctx, query, &outb, &errb)
 	if err != nil {
 		return err
 	}
@@ -75,7 +76,7 @@ func (d *dbImplExec) query(query string, out interface{}) error {
 	return nil
 }
 
-func (d *dbImplExec) ChangeReplicationSource(host, replicaPass string, port int32) error {
+func (d *dbImplExec) ChangeReplicationSource(ctx context.Context, host, replicaPass string, port int32) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf(`
 		CHANGE REPLICATION SOURCE TO
@@ -89,7 +90,7 @@ func (d *dbImplExec) ChangeReplicationSource(host, replicaPass string, port int3
 			SOURCE_RETRY_COUNT=3,
 			SOURCE_CONNECT_RETRY=60
 		`, apiv1alpha1.UserReplication, replicaPass, host, port)
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 
 	if err != nil {
 		return errors.Wrap(err, "exec CHANGE REPLICATION SOURCE TO")
@@ -98,30 +99,30 @@ func (d *dbImplExec) ChangeReplicationSource(host, replicaPass string, port int3
 	return nil
 }
 
-func (d *dbImplExec) StartReplication(host, replicaPass string, port int32) error {
-	if err := d.ChangeReplicationSource(host, replicaPass, port); err != nil {
+func (d *dbImplExec) StartReplication(ctx context.Context, host, replicaPass string, port int32) error {
+	if err := d.ChangeReplicationSource(ctx, host, replicaPass, port); err != nil {
 		return errors.Wrap(err, "change replication source")
 	}
 
 	var errb, outb bytes.Buffer
-	err := d.exec("START REPLICA", &outb, &errb)
+	err := d.exec(ctx, "START REPLICA", &outb, &errb)
 	return errors.Wrap(err, "start replication")
 }
 
-func (d *dbImplExec) StopReplication() error {
+func (d *dbImplExec) StopReplication(ctx context.Context) error {
 	var errb, outb bytes.Buffer
-	err := d.exec("STOP REPLICA", &outb, &errb)
+	err := d.exec(ctx, "STOP REPLICA", &outb, &errb)
 	return errors.Wrap(err, "stop replication")
 }
 
-func (d *dbImplExec) ResetReplication() error {
+func (d *dbImplExec) ResetReplication(ctx context.Context) error {
 	var errb, outb bytes.Buffer
-	err := d.exec("RESET REPLICA ALL", &outb, &errb)
+	err := d.exec(ctx, "RESET REPLICA ALL", &outb, &errb)
 	return errors.Wrap(err, "reset replication")
 
 }
 
-func (d *dbImplExec) ReplicationStatus() (ReplicationStatus, string, error) {
+func (d *dbImplExec) ReplicationStatus(ctx context.Context) (ReplicationStatus, string, error) {
 	rows := []*struct {
 		IoState  string `csv:"conn_state"`
 		SqlState string `csv:"applier_state"`
@@ -140,7 +141,7 @@ func (d *dbImplExec) ReplicationStatus() (ReplicationStatus, string, error) {
             ON connection_status.channel_name = applier_status.channel_name
         WHERE connection_status.channel_name = '%s'
 		`, DefaultChannelName)
-	err := d.query(q, &rows)
+	err := d.query(ctx, q, &rows)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ReplicationStatusNotInitiated, "", nil
@@ -155,23 +156,23 @@ func (d *dbImplExec) ReplicationStatus() (ReplicationStatus, string, error) {
 	return ReplicationStatusNotInitiated, "", err
 }
 
-func (d *dbImplExec) IsReplica() (bool, error) {
-	status, _, err := d.ReplicationStatus()
+func (d *dbImplExec) IsReplica(ctx context.Context) (bool, error) {
+	status, _, err := d.ReplicationStatus(ctx)
 	return status == ReplicationStatusActive, errors.Wrap(err, "get replication status")
 }
 
-func (d *dbImplExec) EnableSuperReadonly() error {
+func (d *dbImplExec) EnableSuperReadonly(ctx context.Context) error {
 	var errb, outb bytes.Buffer
-	err := d.exec("SET GLOBAL SUPER_READ_ONLY=1", &outb, &errb)
+	err := d.exec(ctx, "SET GLOBAL SUPER_READ_ONLY=1", &outb, &errb)
 	return errors.Wrap(err, "set global super_read_only param to 1")
 }
 
-func (d *dbImplExec) IsReadonly() (bool, error) {
+func (d *dbImplExec) IsReadonly(ctx context.Context) (bool, error) {
 	rows := []*struct {
 		Readonly int `csv:"readonly"`
 	}{}
 
-	err := d.query("select @@read_only and @@super_read_only as readonly", &rows)
+	err := d.query(ctx, "select @@read_only and @@super_read_only as readonly", &rows)
 	if err != nil {
 		return false, err
 	}
@@ -179,12 +180,12 @@ func (d *dbImplExec) IsReadonly() (bool, error) {
 	return rows[0].Readonly == 1, nil
 }
 
-func (d *dbImplExec) ReportHost() (string, error) {
+func (d *dbImplExec) ReportHost(ctx context.Context) (string, error) {
 	rows := []*struct {
 		Host string `csv:"host"`
 	}{}
 
-	err := d.query("select @@report_host as host", &rows)
+	err := d.query(ctx, "select @@report_host as host", &rows)
 	if err != nil {
 		return "", err
 	}
@@ -196,11 +197,11 @@ func (d *dbImplExec) Close() error {
 	return nil
 }
 
-func (d *dbImplExec) CloneInProgress() (bool, error) {
+func (d *dbImplExec) CloneInProgress(ctx context.Context) (bool, error) {
 	rows := []*struct {
 		State string `csv:"state"`
 	}{}
-	err := d.query("SELECT STATE FROM clone_status as state", &rows)
+	err := d.query(ctx, "SELECT STATE FROM clone_status as state", &rows)
 	if err != nil {
 		return false, errors.Wrap(err, "fetch clone status")
 	}
@@ -214,12 +215,12 @@ func (d *dbImplExec) CloneInProgress() (bool, error) {
 	return false, nil
 }
 
-func (d *dbImplExec) NeedsClone(donor string, port int32) (bool, error) {
+func (d *dbImplExec) NeedsClone(ctx context.Context, donor string, port int32) (bool, error) {
 	rows := []*struct {
 		Source string `csv:"source"`
 		State  string `csv:"state"`
 	}{}
-	err := d.query("SELECT SOURCE as source, STATE as state FROM clone_status", &rows)
+	err := d.query(ctx, "SELECT SOURCE as source, STATE as state FROM clone_status", &rows)
 	if err != nil {
 		return false, errors.Wrap(err, "fetch clone status")
 	}
@@ -233,16 +234,16 @@ func (d *dbImplExec) NeedsClone(donor string, port int32) (bool, error) {
 	return true, nil
 }
 
-func (d *dbImplExec) Clone(donor, user, pass string, port int32) error {
+func (d *dbImplExec) Clone(ctx context.Context, donor, user, pass string, port int32) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf("SET GLOBAL clone_valid_donor_list='%s'", fmt.Sprintf("%s:%d", donor, port))
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 	if err != nil {
 		return errors.Wrap(err, "set clone_valid_donor_list")
 	}
 
 	q = fmt.Sprintf("CLONE INSTANCE FROM %s@%s:%d IDENTIFIED BY %s", user, donor, port, pass)
-	err = d.exec(q, &outb, &errb)
+	err = d.exec(ctx, q, &outb, &errb)
 
 	if strings.Contains(errb.String(), "ERROR") {
 		return errors.Wrap(err, "clone instance")
@@ -256,34 +257,34 @@ func (d *dbImplExec) Clone(donor, user, pass string, port int32) error {
 	return nil
 }
 
-func (d *dbImplExec) DumbQuery() error {
+func (d *dbImplExec) DumbQuery(ctx context.Context) error {
 	var errb, outb bytes.Buffer
-	err := d.exec("SELECT 1", &outb, &errb)
+	err := d.exec(ctx, "SELECT 1", &outb, &errb)
 
 	return errors.Wrap(err, "SELECT 1")
 }
 
-func (d *dbImplExec) SetSemiSyncSource(enabled bool) error {
+func (d *dbImplExec) SetSemiSyncSource(ctx context.Context, enabled bool) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf("SET GLOBAL rpl_semi_sync_master_enabled=%t", enabled)
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 	return errors.Wrap(err, "set rpl_semi_sync_master_enabled")
 }
 
-func (d *dbImplExec) SetSemiSyncSize(size int) error {
+func (d *dbImplExec) SetSemiSyncSize(ctx context.Context, size int) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf("SET GLOBAL rpl_semi_sync_master_wait_for_slave_count=%d", size)
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 	return errors.Wrap(err, "set rpl_semi_sync_master_wait_for_slave_count")
 }
 
-func (d *dbImplExec) GetGlobal(variable string) (interface{}, error) {
+func (d *dbImplExec) GetGlobal(ctx context.Context, variable string) (interface{}, error) {
 	rows := []*struct {
 		Val interface{} `csv:"val"`
 	}{}
 
 	// TODO: check how to do this without being vulnerable to injection
-	err := d.query(fmt.Sprintf("SELECT @@%s as val", variable), &rows)
+	err := d.query(ctx, fmt.Sprintf("SELECT @@%s as val", variable), &rows)
 	if err != nil {
 		return nil, errors.Wrapf(err, "SELECT @@%s", variable)
 	}
@@ -291,10 +292,10 @@ func (d *dbImplExec) GetGlobal(variable string) (interface{}, error) {
 	return rows[0].Val, nil
 }
 
-func (d *dbImplExec) SetGlobal(variable, value interface{}) error {
+func (d *dbImplExec) SetGlobal(ctx context.Context, variable, value interface{}) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf("SET GLOBAL %s=%s", variable, value)
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 	if err != nil {
 		return errors.Wrapf(err, "SET GLOBAL %s=%s", variable, value)
 
@@ -302,10 +303,10 @@ func (d *dbImplExec) SetGlobal(variable, value interface{}) error {
 	return nil
 }
 
-func (d *dbImplExec) StartGroupReplication(password string) error {
+func (d *dbImplExec) StartGroupReplication(ctx context.Context, password string) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf("START GROUP_REPLICATION USER='%s', PASSWORD='%s'", apiv1alpha1.UserReplication, password)
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 
 	mErr, ok := err.(*mysql.MySQLError)
 	if !ok {
@@ -320,13 +321,13 @@ func (d *dbImplExec) StartGroupReplication(password string) error {
 	return errors.Wrap(err, "start group replication")
 }
 
-func (d *dbImplExec) StopGroupReplication() error {
+func (d *dbImplExec) StopGroupReplication(ctx context.Context) error {
 	var errb, outb bytes.Buffer
-	err := d.exec("STOP GROUP_REPLICATION", &outb, &errb)
+	err := d.exec(ctx, "STOP GROUP_REPLICATION", &outb, &errb)
 	return errors.Wrap(err, "stop group replication")
 }
 
-func (d *dbImplExec) ChangeGroupReplicationPassword(replicaPass string) error {
+func (d *dbImplExec) ChangeGroupReplicationPassword(ctx context.Context, replicaPass string) error {
 	var errb, outb bytes.Buffer
 	q := fmt.Sprintf(`
             CHANGE REPLICATION SOURCE TO
@@ -335,7 +336,7 @@ func (d *dbImplExec) ChangeGroupReplicationPassword(replicaPass string) error {
             FOR CHANNEL 'group_replication_recovery'
         `, apiv1alpha1.UserReplication, replicaPass)
 
-	err := d.exec(q, &outb, &errb)
+	err := d.exec(ctx, q, &outb, &errb)
 	if err != nil {
 		return errors.Wrap(err, "exec CHANGE REPLICATION SOURCE TO")
 	}
@@ -343,12 +344,12 @@ func (d *dbImplExec) ChangeGroupReplicationPassword(replicaPass string) error {
 	return nil
 }
 
-func (d *dbImplExec) GetGroupReplicationPrimary() (string, error) {
+func (d *dbImplExec) GetGroupReplicationPrimary(ctx context.Context) (string, error) {
 	rows := []*struct {
 		Host string `csv:"host"`
 	}{}
 
-	err := d.query("SELECT MEMBER_HOST as host FROM replication_group_members WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE'", &rows)
+	err := d.query(ctx, "SELECT MEMBER_HOST as host FROM replication_group_members WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE'", &rows)
 	if err != nil {
 		return "", errors.Wrap(err, "query primary member")
 	}
@@ -357,12 +358,12 @@ func (d *dbImplExec) GetGroupReplicationPrimary() (string, error) {
 }
 
 // TODO: finish implementation
-func (d *dbImplExec) GetGroupReplicationReplicas() ([]string, error) {
+func (d *dbImplExec) GetGroupReplicationReplicas(ctx context.Context) ([]string, error) {
 	rows := []*struct {
 		Host string `csv:"host"`
 	}{}
 
-	err := d.query("SELECT MEMBER_HOST as host FROM replication_group_members WHERE MEMBER_ROLE='SECONDARY' AND MEMBER_STATE='ONLINE'", &rows)
+	err := d.query(ctx, "SELECT MEMBER_HOST as host FROM replication_group_members WHERE MEMBER_ROLE='SECONDARY' AND MEMBER_STATE='ONLINE'", &rows)
 	if err != nil {
 		return nil, errors.Wrap(err, "query replicas")
 	}
@@ -375,12 +376,12 @@ func (d *dbImplExec) GetGroupReplicationReplicas() ([]string, error) {
 	return replicas, nil
 }
 
-func (d *dbImplExec) GetMemberState(host string) (MemberState, error) {
+func (d *dbImplExec) GetMemberState(ctx context.Context, host string) (MemberState, error) {
 	rows := []*struct {
 		State MemberState `csv:"state"`
 	}{}
 	q := fmt.Sprintf(`SELECT MEMBER_STATE as state FROM replication_group_members WHERE MEMBER_HOST='%s'`, host)
-	err := d.query(q, &rows)
+	err := d.query(ctx, q, &rows)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return MemberStateOffline, nil
@@ -391,12 +392,12 @@ func (d *dbImplExec) GetMemberState(host string) (MemberState, error) {
 	return rows[0].State, nil
 }
 
-func (d *dbImplExec) GetGroupReplicationMembers() ([]string, error) {
+func (d *dbImplExec) GetGroupReplicationMembers(ctx context.Context) ([]string, error) {
 	rows := []*struct {
 		Member string `csv:"member"`
 	}{}
 
-	err := d.query("SELECT MEMBER_HOST as member FROM replication_group_members", &rows)
+	err := d.query(ctx, "SELECT MEMBER_HOST as member FROM replication_group_members", &rows)
 	if err != nil {
 		return nil, errors.Wrap(err, "query members")
 	}
@@ -409,13 +410,13 @@ func (d *dbImplExec) GetGroupReplicationMembers() ([]string, error) {
 	return members, nil
 }
 
-func (d *dbImplExec) CheckIfDatabaseExists(name string) (bool, error) {
+func (d *dbImplExec) CheckIfDatabaseExists(ctx context.Context, name string) (bool, error) {
 	rows := []*struct {
 		DB string `csv:"db"`
 	}{}
 
 	q := fmt.Sprintf("SELECT SCHEMA_NAME AS db FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE '%s'", name)
-	err := d.query(q, &rows)
+	err := d.query(ctx, q, &rows)
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -428,12 +429,12 @@ func (d *dbImplExec) CheckIfDatabaseExists(name string) (bool, error) {
 }
 
 // TODO: finish implementation
-func (d *dbImplExec) CheckIfInPrimaryPartition() (bool, error) {
+func (d *dbImplExec) CheckIfInPrimaryPartition(ctx context.Context) (bool, error) {
 	rows := []*struct {
 		In bool `csv:"in"`
 	}{}
 
-	err := d.query(`
+	err := d.query(ctx, `
 	SELECT
 		MEMBER_STATE = 'ONLINE'
 		AND (
@@ -465,4 +466,22 @@ func (d *dbImplExec) CheckIfInPrimaryPartition() (bool, error) {
 	}
 
 	return rows[0].In, nil
+}
+
+func (d *dbImplExec) CheckIfPrimaryUnreachable(ctx context.Context) (bool, error) {
+	var state string
+
+	err := d.query(ctx, `
+	SELECT
+		MEMBER_STATE
+	FROM
+		performance_schema.replication_group_members
+	WHERE
+		MEMBER_ROLE = 'PRIMARY'
+	`, &state)
+	if err != nil {
+		return false, err
+	}
+
+	return state == string(innodbcluster.MemberStateUnreachable), nil
 }


### PR DESCRIPTION
[![K8SPS-280](https://badgen.net/badge/JIRA/K8SPS-280/green)](https://jira.percona.com/browse/K8SPS-280) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before these changes, we were rebooting the cluster from complete outage from pod-0, without checking which member has the latest transactions. Therefore our full cluster recovery implementation was prone to data loss.

Now we're using mysql-shell's built-in checks to detect the member to reboot from. For this, mysql-shell requires every member to be reachable, so it can connect and check GTID's in each one. That means in case of full cluster crash we need to start each pod and ensure they're reachable.

We're bringing back the `/var/lib/mysql/full-cluster-crash` to address this requirement. Pods create this file if they detect they're in full cluster crash and restart themselves. After the restart, they'll start the mysqld process but ensure the server started as read only. After all pods up and running (ready), the operator will run `dba.rebootClusterFromCompleteOutage()` in one of the MySQL pods. In which pod we run this is not important, since mysql-shell will connect to each pod and select the suitable one to reboot.

*Events*

This commit also introduces the event recorder and two events:

1. FullClusterCrashDetected
2. FullClusterCrashRecovered

Users will be able to see these events on `PerconaServerMySQL` object.

For example:

```
$ kubectl describe ps cluster1
...
Events:
  Type     Reason                     Age                 From           Message
  ----     ------                     ----                ----           -------
  Warning  FullClusterCrashDetected   19m (x10 over 20m)  ps-controller  Full cluster crash detected
  Normal   FullClusterCrashRecovered  17m                 ps-controller  Cluster recovered from full cluster crash
```

*Probe timeouts*

Kubernetes had some problems with timeouts in exec probes which they fixed in recent releases. But we still see problematic behaviors. For example, even though Kubernetes successfully detects the timeout in probe it doesn't count the timeouts as failure. So container is not restarted even if its liveness probe timed out million times. With this commit we're handling timeouts by ourselves with contexts.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?