### PR TITLE
K8SPS-276 - Remove SetSemiSyncSize and SetSemiSyncSource functions

### DIFF
--- a/pkg/replicator/replicatorexec.go
+++ b/pkg/replicator/replicatorexec.go
@@ -259,20 +259,6 @@ func (d *dbImplExec) DumbQuery(ctx context.Context) error {
 	return errors.Wrap(err, "SELECT 1")
 }
 
-func (d *dbImplExec) SetSemiSyncSource(ctx context.Context, enabled bool) error {
-	var errb, outb bytes.Buffer
-	q := fmt.Sprintf("SET GLOBAL rpl_semi_sync_master_enabled=%t", enabled)
-	err := d.exec(ctx, q, &outb, &errb)
-	return errors.Wrap(err, "set rpl_semi_sync_master_enabled")
-}
-
-func (d *dbImplExec) SetSemiSyncSize(ctx context.Context, size int) error {
-	var errb, outb bytes.Buffer
-	q := fmt.Sprintf("SET GLOBAL rpl_semi_sync_master_wait_for_slave_count=%d", size)
-	err := d.exec(ctx, q, &outb, &errb)
-	return errors.Wrap(err, "set rpl_semi_sync_master_wait_for_slave_count")
-}
-
 func (d *dbImplExec) GetGlobal(ctx context.Context, variable string) (interface{}, error) {
 	rows := []*struct {
 		Val interface{} `csv:"val"`


### PR DESCRIPTION
[![K8SPS-276](https://badgen.net/badge/JIRA/K8SPS-276/green)](https://jira.percona.com/browse/K8SPS-276) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Seems they are orphaned functions since semi sync replication is removed completely.*

**Solution:**
*Remove*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?