### PR TITLE
CLOUD-801 - Using #!/usr/bin/env bash instead of #!/bin/bash in the BASH scripts of the e2e tests

### DIFF
--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/e2e-tests/format
+++ b/e2e-tests/format
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TMP=$(mktemp)
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set root repo relatively to a test dir
 ROOT_REPO=${ROOT_REPO:-$(realpath ../../..)}

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export ROOT_REPO=${ROOT_REPO:-${PWD}}
 


### PR DESCRIPTION
[![CLOUD-801](https://badgen.net/badge/JIRA/CLOUD-801/green)](https://jira.percona.com/browse/CLOUD-801) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Appears that on Mac the default /bin/bash shell is not the newest version. For some of the test cases we use BASH features which are available in the latest versions.

Currently, the bash scripts use

#!/bin/bash

at the beginning, which works on recent Linux distros, but not on Macs. Mac users need to install a recent BASH version with macports or homebrew. However, that bash version won't replace the default one. In order to keep the shell scripts consistent, we should use a different shebang line, like this:

#!/usr/bin/env bash

See: stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang