### PR TITLE
CLOUD-789 - Don't ignore pmm-client for password leaks check

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -473,11 +473,7 @@ check_passwords_leak() {
 		for p in $pods; do
 			containers=$(kubectl -n "$NS" get pod $p -o jsonpath='{.spec.containers[*].name}')
 			for c in $containers; do
-				# temporary, because of: https://jira.percona.com/browse/PMM-8357
-				if [[ ${c} =~ "pmm" ]]; then
-					continue
-				fi
-				kubectl -n "$NS" logs $p -c $c > ${TEMP_DIR}/logs_output-$p-$c.txt
+				kubectl -n "$NS" logs $p -c $c >${TEMP_DIR}/logs_output-$p-$c.txt
 				echo logs saved in: ${TEMP_DIR}/logs_output-$p-$c.txt
 				for pass in $passwords; do
 					count=$(grep -c --fixed-strings -- "$pass" ${TEMP_DIR}/logs_output-$p-$c.txt || :)


### PR DESCRIPTION
[![CLOUD-789](https://badgen.net/badge/JIRA/CLOUD-789/green)](https://jira.percona.com/browse/CLOUD-789) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*We were ignoring pmm client container, but for PS operator leaked monitor user password should be fixed under K8SPS-272*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?