### PR TITLE
K8SPS-292: Fix CR status if cluster is paused

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -353,6 +353,8 @@ type StatefulAppState string
 
 const (
 	StateInitializing StatefulAppState = "initializing"
+	StateStopping     StatefulAppState = "stopping"
+	StatePaused       StatefulAppState = "paused"
 	StateReady        StatefulAppState = "ready"
 	StateError        StatefulAppState = "error"
 )

--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -286,11 +286,6 @@ func (r *PerconaServerMySQLReconciler) appStatus(ctx context.Context, cr *apiv1a
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return status, err
 	}
-	if sfsObj.Status.Replicas > sfsObj.Status.UpdatedReplicas {
-		return status, nil
-	}
-
-	sfsObj.Size()
 
 	pods, err := k8s.PodsByLabels(ctx, r.Client, labels)
 	if err != nil {
@@ -303,7 +298,14 @@ func (r *PerconaServerMySQLReconciler) appStatus(ctx context.Context, cr *apiv1a
 		}
 	}
 
-	if status.Ready == status.Size {
+	switch {
+	case cr.Spec.Pause && status.Ready > 0:
+		status.State = apiv1alpha1.StateStopping
+	case cr.Spec.Pause && status.Ready == 0:
+		status.State = apiv1alpha1.StatePaused
+	case sfsObj.Status.Replicas > sfsObj.Status.UpdatedReplicas:
+		status.State = apiv1alpha1.StateInitializing
+	case status.Ready == status.Size:
 		status.State = apiv1alpha1.StateReady
 	}
 


### PR DESCRIPTION
[![K8SPS-292](https://badgen.net/badge/JIRA/K8SPS-292/green)](https://jira.percona.com/browse/K8SPS-292) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
CR status is initializing if cluster is paused. It should be `stopping` while pods are terminating and `paused` when cluster is paused.

**Cause:**
Not implemented.

**Solution:**
Implement.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?