### PR TITLE
K8SPS-305: fix pause for gr cluster with haproxy

### DIFF
--- a/e2e-tests/run-distro.csv
+++ b/e2e-tests/run-distro.csv
@@ -3,6 +3,7 @@ config
 config-router
 demand-backup
 gr-demand-backup
+gr-demand-backup-haproxy
 gr-haproxy
 gr-init-deploy
 gr-one-pod

--- a/e2e-tests/run-minikube.csv
+++ b/e2e-tests/run-minikube.csv
@@ -3,6 +3,7 @@ config
 config-router
 demand-backup
 gr-demand-backup
+gr-demand-backup-haproxy
 gr-haproxy
 gr-init-deploy
 gr-one-pod

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -4,6 +4,7 @@ config
 config-router
 demand-backup
 gr-demand-backup
+gr-demand-backup-haproxy
 gr-haproxy
 gr-ignore-annotations
 gr-init-deploy

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -4,6 +4,7 @@ config
 config-router
 demand-backup
 gr-demand-backup
+gr-demand-backup-haproxy
 gr-haproxy
 gr-ignore-annotations
 gr-init-deploy

--- a/e2e-tests/tests/gr-demand-backup-haproxy/00-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/00-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+type: Opaque

--- a/e2e-tests/tests/gr-demand-backup-haproxy/00-minio-secret.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/00-minio-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+stringData:
+  AWS_ACCESS_KEY_ID: some-access$\n"-key
+  AWS_SECRET_ACCESS_KEY: some-$\n"secret-key

--- a/e2e-tests/tests/gr-demand-backup-haproxy/01-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/01-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermysqls.ps.percona.com
+spec:
+  group: ps.percona.com
+  names:
+    kind: PerconaServerMySQL
+    listKind: PerconaServerMySQLList
+    plural: perconaservermysqls
+    shortNames:
+    - ps
+    singular: perconaservermysql
+  scope: Namespaced
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: percona-server-mysql-operator
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/e2e-tests/tests/gr-demand-backup-haproxy/01-deploy-operator.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/01-deploy-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      deploy_operator
+      deploy_non_tls_cluster_secrets
+      deploy_tls_cluster_secrets
+      deploy_client
+      deploy_minio
+    timeout: 300

--- a/e2e-tests/tests/gr-demand-backup-haproxy/02-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/02-assert.yaml
@@ -1,0 +1,47 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 420
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-demand-backup-haproxy-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-demand-backup-haproxy-haproxy
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-demand-backup-haproxy
+status:
+  conditions:
+  - message: InnoDB cluster successfully bootstrapped with 3 nodes
+    reason: InnoDBClusterBootstrapped
+    status: "True"
+    type: InnoDBClusterBootstrapped
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  haproxy:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-demand-backup-haproxy/02-create-cluster.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/02-create-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      get_cr \
+      	| yq eval '.spec.backup.storages.minio.type="s3"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.bucket="operator-testing"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.credentialsSecret="minio-secret"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.endpointUrl="http://minio-service:9000"' - \
+      	| yq eval '.spec.backup.storages.minio.s3.region="us-east-1"' - \
+      	| yq eval '.spec.mysql.clusterType="group-replication"' - \
+      	| yq eval '.spec.proxy.router.enabled=false' - \
+      	| yq eval '.spec.proxy.haproxy.enabled=true' - \
+      	| kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/gr-demand-backup-haproxy/03-write-data.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/03-write-data.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o pipefail
+      set -o xtrace
+
+      source ../../functions
+
+      run_mysql \
+      	"CREATE DATABASE IF NOT EXISTS myDB; CREATE TABLE IF NOT EXISTS myDB.myTable (id int PRIMARY KEY)" \
+      	"-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password"
+
+      run_mysql \
+      	"INSERT myDB.myTable (id) VALUES (100500)" \
+      	"-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password"

--- a/e2e-tests/tests/gr-demand-backup-haproxy/04-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/04-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: PerconaServerMySQLBackup
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: gr-demand-backup-haproxy-minio
+status:
+  state: Succeeded
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-demand-backup-haproxy-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-demand-backup-haproxy-haproxy
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0

--- a/e2e-tests/tests/gr-demand-backup-haproxy/04-create-backup-minio.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/04-create-backup-minio.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLBackup
+metadata:
+  name: gr-demand-backup-haproxy-minio
+spec:
+  clusterName: gr-demand-backup-haproxy
+  storageName: minio

--- a/e2e-tests/tests/gr-demand-backup-haproxy/05-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/05-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-0
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-1
+data:
+  data: ""
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 04-delete-data-minio-2
+data:
+  data: ""

--- a/e2e-tests/tests/gr-demand-backup-haproxy/05-delete-data.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/05-delete-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      run_mysql \
+      	"TRUNCATE TABLE myDB.myTable" \
+      	"-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password"
+
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2; do
+      	data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
+      	kubectl create configmap -n "${NAMESPACE}" 04-delete-data-minio-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/gr-demand-backup-haproxy/06-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/06-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 500
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-demand-backup-haproxy
+status:
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  haproxy:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready
+---
+kind: PerconaServerMySQLRestore
+apiVersion: ps.percona.com/v1alpha1
+metadata:
+  name: gr-demand-backup-haproxy-restore-minio
+status:
+  state: Succeeded

--- a/e2e-tests/tests/gr-demand-backup-haproxy/06-restore-from-minio.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/06-restore-from-minio.yaml
@@ -1,0 +1,7 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQLRestore
+metadata:
+  name: gr-demand-backup-haproxy-restore-minio
+spec:
+  clusterName: gr-demand-backup-haproxy
+  backupName: gr-demand-backup-haproxy-minio

--- a/e2e-tests/tests/gr-demand-backup-haproxy/07-assert.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/07-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-minio-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/gr-demand-backup-haproxy/07-read-data.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/07-read-data.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2; do
+      	data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -proot_password")
+      	kubectl create configmap -n "${NAMESPACE}" 06-read-data-minio-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/gr-demand-backup-haproxy/08-drop-finalizer.yaml
+++ b/e2e-tests/tests/gr-demand-backup-haproxy/08-drop-finalizer.yaml
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-demand-backup-haproxy
+  finalizers: []


### PR DESCRIPTION
[![K8SPS-305](https://badgen.net/badge/JIRA/K8SPS-305/green)](https://jira.percona.com/browse/K8SPS-305) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPS-305

**DESCRIPTION**
---
**Problem:**
*Pause doesn't work for group-replication cluster with haproxy enabled.*

**Cause:**
*The function `pauseCluster` did not consider enabling haproxy for group-replication cluster and failed to find router deployment.*

**Solution:**
*Fix `pauseCluster` function. Add `gr-demand-backup-haproxy` test*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?