### PR TITLE
K8SPS-309: restore doesn't restart cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/apimachinery v0.27.4
 	k8s.io/client-go v0.27.4
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
-	sigs.k8s.io/controller-runtime v0.15.0
+	sigs.k8s.io/controller-runtime v0.15.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -863,8 +863,8 @@ k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/controller-runtime v0.15.0 h1:ML+5Adt3qZnMSYxZ7gAverBLNPSMQEibtzAgp0UPojU=
-sigs.k8s.io/controller-runtime v0.15.0/go.mod h1:7ngYvp1MLT+9GeZ+6lH3LOlcHkp/+tzA/fmHa4iq9kk=
+sigs.k8s.io/controller-runtime v0.15.2 h1:9V7b7SDQSJ08IIsJ6CY1CE85Okhp87dyTMNDG0FS7f4=
+sigs.k8s.io/controller-runtime v0.15.2/go.mod h1:7ngYvp1MLT+9GeZ+6lH3LOlcHkp/+tzA/fmHa4iq9kk=
 sigs.k8s.io/gateway-api v0.7.0 h1:/mG8yyJNBifqvuVLW5gwlI4CQs0NR/5q4BKUlf1bVdY=
 sigs.k8s.io/gateway-api v0.7.0/go.mod h1:Xv0+ZMxX0lu1nSSDIIPEfbVztgNZ+3cfiYrJsa2Ooso=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -322,10 +322,6 @@ func writeStatus(ctx context.Context, cl client.Client, nn types.NamespacedName,
 		}
 
 		cr.Status = status
-		if err := cl.Status().Update(ctx, cr); err != nil {
-			return errors.Wrapf(err, "update %v", nn.String())
-		}
-
-		return nil
+		return cl.Status().Update(ctx, cr)
 	})
 }

--- a/pkg/controller/psbackup/controller.go
+++ b/pkg/controller/psbackup/controller.go
@@ -105,11 +105,7 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 
 			cr.Status = status
 			log.Info("Updating status", "state", cr.Status.State)
-			if err := r.Client.Status().Update(ctx, cr); err != nil {
-				return errors.Wrapf(err, "update %v", req.NamespacedName.String())
-			}
-
-			return nil
+			return r.Client.Status().Update(ctx, cr)
 		})
 		if err != nil {
 			log.Error(err, "failed to update status")


### PR DESCRIPTION
[![K8SPS-309](https://badgen.net/badge/JIRA/K8SPS-309/green)](https://jira.percona.com/browse/K8SPS-309) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPS-309

**DESCRIPTION**
---
**Problem:**
*On rare occasions, the cluster doesn't restart after being restored.*

**Cause:**
*Sometimes, the operator fails to update the status of `PerconaServerMySQLRestore` even if there is no error. When the operator fails to update to the `Succeeded` state, it will pause the cluster on the next `Reconcile` call. This can cause the cluster to get stuck in a loop where the operator repeatedly pauses and unpauses it.*

*Additionally, it is possible that after a successful update of the status, the operator may encounter an error during the code execution for `Error` state checks. This could cause the operator to update the state to `Error` and then back to the `New` state, resulting in the cluster being paused once again.*

**Solution:**
*We should check if the state was updated after the update call at the end of `Reconcile` and try to update it once again if it fails.*

*We should not execute `Error` state checks if restoration has a `Succeeded` or `Failed` state.*

**Additional fixes**
- *Updated `sigs.k8s.io/controller-runtime` to `v0.15.2`*
- *[RetryOnConflict](https://github.com/kubernetes/client-go/blob/v0.27.4/util/retry/util.go#L103) function expects [unmodified error from the update function](https://github.com/kubernetes/client-go/blob/v0.27.4/util/retry/util.go#L71C29-L71C76). Removed wrapping in all places where errors are returned by the update function.*
- *Fixed possible stuck in the `Starting` state if the restore job finished but the `PerconaServerMySQLRestore` still has the `Starting` state*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?