### PR TITLE
K8SPS-232: Fix restore in async cluster

### DIFF
--- a/cmd/bootstrap/async_replication.go
+++ b/cmd/bootstrap/async_replication.go
@@ -140,6 +140,10 @@ func bootstrapAsyncReplication(ctx context.Context) error {
 			return nil
 		}
 
+		if err := db.DisableSuperReadonly(ctx); err != nil {
+			return errors.Wrap(err, "disable super read only")
+		}
+
 		timer.Start("clone")
 		log.Printf("Cloning from %s", donor)
 		err = db.Clone(ctx, donor, string(apiv1alpha1.UserOperator), operatorPass, mysql.DefaultAdminPort)

--- a/pkg/replicator/replicator.go
+++ b/pkg/replicator/replicator.go
@@ -43,6 +43,7 @@ type Replicator interface {
 	ResetReplication(ctx context.Context) error
 	ReplicationStatus(ctx context.Context) (ReplicationStatus, string, error)
 	EnableSuperReadonly(ctx context.Context) error
+	DisableSuperReadonly(ctx context.Context) error
 	IsReadonly(ctx context.Context) (bool, error)
 	ReportHost(ctx context.Context) (string, error)
 	Close() error
@@ -171,6 +172,11 @@ func (d *dbImpl) IsReplica(ctx context.Context) (bool, error) {
 func (d *dbImpl) EnableSuperReadonly(ctx context.Context) error {
 	_, err := d.db.ExecContext(ctx, "SET GLOBAL SUPER_READ_ONLY=1")
 	return errors.Wrap(err, "set global super_read_only param to 1")
+}
+
+func (d *dbImpl) DisableSuperReadonly(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, "SET GLOBAL SUPER_READ_ONLY=0")
+	return errors.Wrap(err, "set global super_read_only param to 0")
 }
 
 func (d *dbImpl) IsReadonly(ctx context.Context) (bool, error) {

--- a/pkg/replicator/replicatorexec.go
+++ b/pkg/replicator/replicatorexec.go
@@ -162,6 +162,12 @@ func (d *dbImplExec) EnableSuperReadonly(ctx context.Context) error {
 	return errors.Wrap(err, "set global super_read_only param to 1")
 }
 
+func (d *dbImplExec) DisableSuperReadonly(ctx context.Context) error {
+	var errb, outb bytes.Buffer
+	err := d.exec(ctx, "SET GLOBAL SUPER_READ_ONLY=0", &outb, &errb)
+	return errors.Wrap(err, "set global super_read_only param to 0")
+}
+
 func (d *dbImplExec) IsReadonly(ctx context.Context) (bool, error) {
 	rows := []*struct {
 		Readonly int `csv:"readonly"`


### PR DESCRIPTION
[![K8SPS-232](https://badgen.net/badge/JIRA/K8SPS-232/green)](https://jira.percona.com/browse/K8SPS-232) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Clone fails because of `super_read_only`.

**Solution:**
Disable `super_read_only` before clone.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?