### PR TITLE
CLOUD-825 - Use community helm chart repo for installing MinIO

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -90,8 +90,10 @@ delete_pmm_api_key() {
 }
 
 deploy_minio() {
-	local accessKey="$(kubectl -n "${NAMESPACE}" get secret minio-secret -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)"
-	local secretKey="$(kubectl -n "${NAMESPACE}" get secret minio-secret -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)"
+	local access_key
+	local secret_key
+	access_key="$(kubectl -n "${NAMESPACE}" get secret minio-secret -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)"
+	secret_key="$(kubectl -n "${NAMESPACE}" get secret minio-secret -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)"
 
 	helm uninstall -n "${NAMESPACE}" minio-service || :
 	helm repo remove minio || :
@@ -104,8 +106,8 @@ deploy_minio() {
 		--set resources.requests.memory=256Mi \
 		--set rootUser=rootuser \
 		--set rootPassword=rootpass123 \
-		--set "users[0].accessKey"="$(printf '%q' "$accessKey")" \
-		--set "users[0].secretKey"="$(printf '%q' "$secretKey")" \
+		--set "users[0].accessKey"="$(printf '%q' "$(printf '%q' "$access_key")")" \
+		--set "users[0].secretKey"="$(printf '%q' "$(printf '%q' "$secret_key")")" \
 		--set "users[0].policy"=consoleAdmin \
 		--set service.type=ClusterIP \
 		--set configPathmc=/tmp/.minio/ \
@@ -117,7 +119,7 @@ deploy_minio() {
 
 	# create bucket
 	kubectl -n "${NAMESPACE}" run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
-		bash -c "AWS_ACCESS_KEY_ID='$accessKey' AWS_SECRET_ACCESS_KEY='$secretKey' AWS_DEFAULT_REGION=us-east-1 \
+		bash -c "AWS_ACCESS_KEY_ID='$access_key' AWS_SECRET_ACCESS_KEY='$secret_key' AWS_DEFAULT_REGION=us-east-1 \
         /usr/bin/aws --endpoint-url http://minio-service:9000 s3 mb s3://operator-testing"
 }
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -95,17 +95,21 @@ deploy_minio() {
 
 	helm uninstall -n "${NAMESPACE}" minio-service || :
 	helm repo remove minio || :
-	helm repo add minio https://helm.min.io/
+	helm repo add minio https://charts.min.io/
 	retry 10 60 helm install minio-service \
 		-n "${NAMESPACE}" \
-		--version 8.0.5 \
-		--set accessKey="$(printf '%q' "$accessKey")" \
-		--set secretKey="$(printf '%q' "$secretKey")" \
+		--version 5.0.14 \
+		--set replicas=1 \
+		--set mode=standalone \
+		--set resources.requests.memory=256Mi \
+		--set rootUser=rootuser \
+		--set rootPassword=rootpass123 \
+		--set "users[0].accessKey"="$(printf '%q' "$accessKey")" \
+		--set "users[0].secretKey"="$(printf '%q' "$secretKey")" \
+		--set "users[0].policy"=consoleAdmin \
 		--set service.type=ClusterIP \
 		--set configPathmc=/tmp/.minio/ \
 		--set persistence.size=2G \
-		--set environment.MINIO_REGION=us-east-1 \
-		--set environment.MINIO_HTTP_TRACE=/tmp/trace.log \
 		--set securityContext.enabled=false \
 		minio/minio
 	MINIO_POD=$(kubectl -n "${NAMESPACE}" get pods --selector=release=minio-service -o 'jsonpath={.items[].metadata.name}')


### PR DESCRIPTION
[![CLOUD-825](https://badgen.net/badge/JIRA/CLOUD-825/green)](https://jira.percona.com/browse/CLOUD-825) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*https://helm.min.io/ is removed so we need to fix our tests to use something else.*

**Solution:**
*Since official docs use operator+tenants mode we decided to use [community helm](https://charts.min.io/) chart in standalone mode for tests (which is the same what we had before).*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?