### PR TITLE
K8SPS-173: K8SPS-173: Log setting safe size if the unsafe config is not allowed

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -628,6 +628,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersi
 
 	if cr.Spec.MySQL.ClusterType == ClusterTypeGR && !cr.Spec.AllowUnsafeConfig {
 		if cr.Spec.MySQL.Size < MinSafeGRSize {
+			log.Info("Setting safe defaults, updating MySQL cluster size", "oldSize", cr.Spec.MySQL.Size, "newSafeSize", MinSafeGRSize)
 			cr.Spec.MySQL.Size = MinSafeGRSize
 		}
 
@@ -646,6 +647,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersi
 
 	if cr.RouterEnabled() && !cr.Spec.AllowUnsafeConfig {
 		if cr.Spec.Proxy.Router.Size < MinSafeProxySize {
+			log.Info("Setting safe defaults, updating Router size", "oldSize", cr.Spec.Proxy.Router.Size, "newSafeSize", MinSafeProxySize)
 			cr.Spec.Proxy.Router.Size = MinSafeProxySize
 		}
 	}
@@ -656,6 +658,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(ctx context.Context, serverVersi
 
 	if cr.HAProxyEnabled() && !cr.Spec.AllowUnsafeConfig {
 		if cr.Spec.Proxy.HAProxy.Size < MinSafeProxySize {
+			log.Info("Setting safe defaults, updating HAProxy size", "oldSize", cr.Spec.Proxy.HAProxy.Size, "newSafeSize", MinSafeProxySize)
 			cr.Spec.Proxy.HAProxy.Size = MinSafeProxySize
 		}
 	}


### PR DESCRIPTION
[![K8SPS-173](https://badgen.net/badge/JIRA/K8SPS-173/green)](https://jira.percona.com/browse/K8SPS-173) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Resetting a component size to the minimum size allowed when `allowUnsafeConfig` is not set is invisible to the user and can lead to confusion. 

**Solution:**
Log setting safe size if the unsafe config is not allowed

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-173]: https://perconadev.atlassian.net/browse/K8SPS-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ