### PR TITLE
K8SPS-314 - Lower backoffLimit from 10 to 6 as in cr.yaml example

### DIFF
--- a/pkg/xtrabackup/xtrabackup.go
+++ b/pkg/xtrabackup/xtrabackup.go
@@ -72,7 +72,7 @@ func Job(
 	t := true
 
 	labels := util.SSMapMerge(storage.Labels, MatchLabels(cluster))
-	backoffLimit := int32(10)
+	backoffLimit := int32(6)
 	if cluster.Spec.Backup.BackoffLimit != nil {
 		backoffLimit = *cluster.Spec.Backup.BackoffLimit
 	}


### PR DESCRIPTION
[![K8SPS-314](https://badgen.net/badge/JIRA/K8SPS-314/green)](https://jira.percona.com/browse/K8SPS-314) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Current backoffLimit of 10 seems to be too high for no apparent reason and the example in cr.yaml suggests that the default is 6*

**Solution:**
*For now make it the same as example in cr.yaml*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-314]: https://perconadev.atlassian.net/browse/K8SPS-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ