### PR TITLE
K8SPS-314 - Add upgrade strategy to operator.yaml

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: perconalab/percona-server-mysql-operator
-  newName: perconalab/percona-server-mysql-operator
-  newTag: main
+  newName: percona/percona-server-mysql-operator
+  newTag: 0.7.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,6 +8,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: percona-server-mysql-operator
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -9725,6 +9725,10 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: percona-server-mysql-operator
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,10 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: percona-server-mysql-operator
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
[![K8SPS-314](https://badgen.net/badge/JIRA/K8SPS-314/green)](https://jira.percona.com/browse/K8SPS-314) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Operator upgrade fails because previous pod is not replaced with the new one.*

**Cause:**
*Missing upgrade strategy for operator deployment.*

**Solution:**
*Add upgrade strategy to operator deployment.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-314]: https://perconadev.atlassian.net/browse/K8SPS-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ