### PR TITLE
CLOUD-850 - Update kuttl version to 0.16.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,8 +252,8 @@ void prepareNode() {
 
         kubectl krew install assert
 
-        # v0.15.0 kuttl version
-        kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/a67f31ecb2e62f15149ca66d096357050f07b77d/plugins/kuttl.yaml
+        # v0.16.0 kuttl version
+        kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/e450fd06ebe9ce200355726b81d13e5e59b9bf47/plugins/kuttl.yaml
         echo \$(kubectl kuttl --version) is installed
 
         curl -fsSL https://github.com/kyverno/chainsaw/releases/download/v0.1.7/chainsaw_linux_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - chainsaw

--- a/e2e-tests/conf/cmctl.yml
+++ b/e2e-tests/conf/cmctl.yml
@@ -21,7 +21,7 @@ spec:
           - /bin/sh
           - -c
           - |
-            curl -fsSL -o /tmp/cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-linux-amd64.tar.gz \
-            && tar -C /tmp -xzf /tmp/cmctl.tar.gz \
+            curl -fsSL -o /tmp/cmctl https://github.com/cert-manager/cmctl/releases/download/v2.0.0/cmctl_linux_amd64 \
+            && chmod +x /tmp/cmctl \
             && sleep 100500
       restartPolicy: Always


### PR DESCRIPTION
[![CLOUD-850](https://badgen.net/badge/JIRA/CLOUD-850/green)](https://jira.percona.com/browse/CLOUD-850) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Update kuttl framework version to 0.16.0 and fix download of cert manager cmctl tool.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-850]: https://perconadev.atlassian.net/browse/CLOUD-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ