### PR TITLE
K8SPS-362: Fix version service

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -515,7 +515,6 @@ deploy_version_service() {
 	kubectl apply -n "${OPERATOR_NS:-$NAMESPACE}" -f "${TESTS_CONFIG_DIR}/vs.yaml"
 	VS_POD_NAME=$(kubectl -n "${OPERATOR_NS:-$NAMESPACE}" get pods --selector=name=percona-version-service -o 'jsonpath={.items[].metadata.name}')
 	wait_pod $VS_POD_NAME
-	sleep 5
 }
 
 deploy_cert_manager() {

--- a/pkg/controller/ps/version.go
+++ b/pkg/controller/ps/version.go
@@ -5,10 +5,12 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	k8sretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1alpha1 "github.com/percona/percona-server-mysql-operator/api/v1alpha1"
+	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
 	vs "github.com/percona/percona-server-mysql-operator/pkg/version/service"
 )
 
@@ -50,65 +52,86 @@ func (r *PerconaServerMySQLReconciler) reconcileVersions(ctx context.Context, cr
 		return errors.Wrap(err, "failed to get versions")
 	}
 
-	patch := client.MergeFrom(cr.DeepCopy())
-	if cr.Spec.MySQL.Image != version.PSImage {
-		if cr.Status.MySQL.Version == "" {
-			log.Info("set MySQL version to " + version.PSVersion)
-		} else {
-			log.Info("update MySQL version", "old version", cr.Status.MySQL.Version, "new version", version.PSVersion)
+	printedMsg := false
+	shouldUpdate := false
+	nn := client.ObjectKeyFromObject(cr)
+	err = k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+		cr, err := k8s.GetCRWithDefaults(ctx, r.Client, nn, r.ServerVersion)
+		if err != nil {
+			return errors.Wrap(err, "get cr with defaults")
 		}
-		cr.Spec.MySQL.Image = version.PSImage
-	}
-	if cr.Spec.Backup.Image != version.BackupImage {
-		if cr.Status.BackupVersion == "" {
-			log.Info("set backup version to " + version.BackupVersion)
-		} else {
-			log.Info("update backup version", "old version", cr.Status.BackupVersion, "new version", version.BackupVersion)
+		logMsg := func(msg string, keysAndValues ...any) {
+			if printedMsg {
+				return
+			}
+			shouldUpdate = true
+			log.Info(msg, keysAndValues...)
 		}
-		cr.Spec.Backup.Image = version.BackupImage
-	}
-	if cr.Spec.Orchestrator.Image != version.OrchestratorImage {
-		if cr.Status.Orchestrator.Version == "" {
-			log.Info("set orchestrator version to " + version.OrchestratorVersion)
-		} else {
-			log.Info("update orchestrator version", "old version", cr.Status.Orchestrator.Version, "new version", version.OrchestratorVersion)
-		}
-		cr.Spec.Orchestrator.Image = version.OrchestratorImage
-	}
-	if cr.Spec.Proxy.Router.Image != version.RouterImage {
-		if cr.Status.Router.Version == "" {
-			log.Info("set MySQL router version to " + version.RouterVersion)
-		} else {
-			log.Info("update MySQL router version", "old version", cr.Status.Router.Version, "new version", version.RouterVersion)
-		}
-		cr.Spec.Proxy.Router.Image = version.RouterImage
-	}
-	if cr.Spec.PMM.Image != version.PMMImage {
-		if cr.Status.PMMVersion == "" {
-			log.Info("set PMM version to " + version.PMMVersion)
-		} else {
-			log.Info("update PMM version", "old version", cr.Status.PMMVersion, "new version", version.PMMVersion)
-		}
-		cr.Spec.PMM.Image = version.PMMImage
-	}
-	if cr.Spec.Proxy.HAProxy.Image != version.HAProxyImage {
-		if cr.Status.HAProxy.Version == "" {
-			log.Info("set HAProxy version to " + version.HAProxyVersion)
-		} else {
-			log.Info("update HAProxy version", "old version", cr.Status.HAProxy.Version, "new version", version.HAProxyVersion)
-		}
-		cr.Spec.Proxy.HAProxy.Image = version.HAProxyImage
-	}
-	if cr.Spec.Toolkit.Image != version.ToolkitImage {
-		if cr.Status.ToolkitVersion == "" {
-			log.Info("set Percona Toolkit version to " + version.ToolkitVersion)
-		} else {
-			log.Info("update Percona Toolkit version", "old version", cr.Status.ToolkitVersion, "new version", version.ToolkitVersion)
-		}
-		cr.Spec.Toolkit.Image = version.ToolkitImage
-	}
 
-	err = r.Patch(ctx, cr.DeepCopy(), patch)
+		if cr.Spec.MySQL.Image != version.PSImage {
+			if cr.Status.MySQL.Version == "" {
+				logMsg("set MySQL version to " + version.PSVersion)
+			} else {
+				logMsg("update MySQL version", "old version", cr.Status.MySQL.Version, "new version", version.PSVersion)
+			}
+			cr.Spec.MySQL.Image = version.PSImage
+		}
+		if cr.Spec.Backup.Image != version.BackupImage {
+			if cr.Status.BackupVersion == "" {
+				logMsg("set backup version to " + version.BackupVersion)
+			} else {
+				logMsg("update backup version", "old version", cr.Status.BackupVersion, "new version", version.BackupVersion)
+			}
+			cr.Spec.Backup.Image = version.BackupImage
+		}
+		if cr.Spec.Orchestrator.Image != version.OrchestratorImage {
+			if cr.Status.Orchestrator.Version == "" {
+				logMsg("set orchestrator version to " + version.OrchestratorVersion)
+			} else {
+				logMsg("update orchestrator version", "old version", cr.Status.Orchestrator.Version, "new version", version.OrchestratorVersion)
+			}
+			cr.Spec.Orchestrator.Image = version.OrchestratorImage
+		}
+		if cr.Spec.Proxy.Router.Image != version.RouterImage {
+			if cr.Status.Router.Version == "" {
+				logMsg("set MySQL router version to " + version.RouterVersion)
+			} else {
+				logMsg("update MySQL router version", "old version", cr.Status.Router.Version, "new version", version.RouterVersion)
+			}
+			cr.Spec.Proxy.Router.Image = version.RouterImage
+		}
+		if cr.Spec.PMM.Image != version.PMMImage {
+			if cr.Status.PMMVersion == "" {
+				logMsg("set PMM version to " + version.PMMVersion)
+			} else {
+				logMsg("update PMM version", "old version", cr.Status.PMMVersion, "new version", version.PMMVersion)
+			}
+			cr.Spec.PMM.Image = version.PMMImage
+		}
+		if cr.Spec.Proxy.HAProxy.Image != version.HAProxyImage {
+			if cr.Status.HAProxy.Version == "" {
+				logMsg("set HAProxy version to " + version.HAProxyVersion)
+			} else {
+				logMsg("update HAProxy version", "old version", cr.Status.HAProxy.Version, "new version", version.HAProxyVersion)
+			}
+			cr.Spec.Proxy.HAProxy.Image = version.HAProxyImage
+		}
+		if cr.Spec.Toolkit.Image != version.ToolkitImage {
+			if cr.Status.ToolkitVersion == "" {
+				logMsg("set Percona Toolkit version to " + version.ToolkitVersion)
+			} else {
+				logMsg("update Percona Toolkit version", "old version", cr.Status.ToolkitVersion, "new version", version.ToolkitVersion)
+			}
+			cr.Spec.Toolkit.Image = version.ToolkitImage
+		}
+
+		printedMsg = true
+		if !shouldUpdate {
+			return nil
+		}
+
+		return r.Client.Update(ctx, cr)
+	})
 	if err != nil {
 		log.Info("failed to update CR, using the default version")
 		return errors.Wrap(err, "failed to update CR")
@@ -121,5 +144,9 @@ func (r *PerconaServerMySQLReconciler) reconcileVersions(ctx context.Context, cr
 	cr.Status.PMMVersion = version.PMMVersion
 	cr.Status.HAProxy.Version = version.HAProxyVersion
 	cr.Status.ToolkitVersion = version.ToolkitVersion
+
+	if shouldUpdate {
+		return ErrShouldReconcile
+	}
 	return nil
 }

--- a/pkg/controller/ps/version_test.go
+++ b/pkg/controller/ps/version_test.go
@@ -293,7 +293,7 @@ func TestReconcileVersions(t *testing.T) {
 			}
 
 			if err := r.reconcileVersions(ctx, cr); err != nil {
-				if tt.shouldErr {
+				if tt.shouldErr || errors.Is(err, ErrShouldReconcile) {
 					return
 				}
 				t.Fatal(err, "failed to reconcile versions")
@@ -536,6 +536,7 @@ type mockClientConn struct {
 func (m *mockClientConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
 	return grpcmock.InvokeUnary(ctx, method, args, reply, grpcmock.WithInsecure(), grpcmock.WithCallOptions(opts...), grpcmock.WithContextDialer(m.dialer))
 }
+
 func (m *mockClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	return nil, errors.New("unimplemented")
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPS-362

**DESCRIPTION**
---
**Problem:**
*The `version-service` test sometimes fails at the first step because statefulsets are updated with new images obtained from the version service immediately after they are created. We expect the statefulset to already have the new images without the need for an update.*

**Cause:**
*When the patch operation in the `(*PerconaServerMySQLReconciler) reconcileVersions` method fails, the operator continues to create the statefulsets with old images.*

**Solution:**
*We should replace the patch operation with an update. It gives more chances that the cluster will be updated with new images before creating statefulsets.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?