### PR TITLE
K8SPS-366: Reconcile status only on a non-nil CR

### DIFF
--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -29,6 +29,10 @@ import (
 )
 
 func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr *apiv1alpha1.PerconaServerMySQL, reconcileErr error) error {
+	if cr == nil || cr.ObjectMeta.DeletionTimestamp != nil {
+		return nil
+	}
+
 	clusterCondition := metav1.Condition{
 		Status:             metav1.ConditionTrue,
 		Type:               apiv1alpha1.StateInitializing.String(),
@@ -55,10 +59,6 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 	}
 
 	log := logf.FromContext(ctx).WithName("reconcileCRStatus")
-
-	if cr == nil || cr.ObjectMeta.DeletionTimestamp != nil {
-		return nil
-	}
 
 	mysqlStatus, err := r.appStatus(ctx, cr, mysql.Name(cr), cr.MySQLSpec().Size, mysql.MatchLabels(cr), cr.Status.MySQL.Version)
 	if err != nil {


### PR DESCRIPTION
[![K8SPS-366](https://badgen.net/badge/JIRA/K8SPS-366/green)](https://jira.percona.com/browse/K8SPS-366) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
On cluster delete the operator panics since we reconcile the status in a defer when there is no CR because it is deleted.

**Solution:**
Reconcile status only on a non-nil CR.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-366]: https://perconadev.atlassian.net/browse/K8SPS-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ