### PR TITLE
K8SPS-241: Get K8S objects within a specific namespace

### DIFF
--- a/cmd/orc-handler/main.go
+++ b/cmd/orc-handler/main.go
@@ -107,7 +107,7 @@ func setPrimaryLabel(ctx context.Context, primary string) error {
 
 	primaryName := strings.TrimSuffix(strings.TrimSuffix(primary, "."+ns), "."+mysql.ServiceName(cr))
 
-	pods, err := k8s.PodsByLabels(ctx, cl, mysql.MatchLabels(cr))
+	pods, err := k8s.PodsByLabels(ctx, cl, mysql.MatchLabels(cr), cr.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "get MySQL pods")
 	}

--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -142,7 +142,7 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 	}
 
 	if cr.Spec.MySQL.IsGR() {
-		pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr))
+		pods, err := k8s.PodsByLabels(ctx, r.Client, mysql.MatchLabels(cr), cr.Namespace)
 		if err != nil {
 			return errors.Wrap(err, "get pods")
 		}
@@ -377,7 +377,7 @@ func (r *PerconaServerMySQLReconciler) appStatus(ctx context.Context, cr *apiv1a
 		return status, err
 	}
 
-	pods, err := k8s.PodsByLabels(ctx, r.Client, labels)
+	pods, err := k8s.PodsByLabels(ctx, r.Client, labels, cr.Namespace)
 	if err != nil {
 		return status, errors.Wrap(err, "get pod list")
 	}

--- a/pkg/controller/psrestore/controller.go
+++ b/pkg/controller/psrestore/controller.go
@@ -257,7 +257,7 @@ func (r *PerconaServerMySQLRestoreReconciler) Reconcile(ctx context.Context, req
 func (r *PerconaServerMySQLRestoreReconciler) deletePVCs(ctx context.Context, cluster *apiv1alpha1.PerconaServerMySQL) error {
 	log := logf.FromContext(ctx)
 
-	pvcs, err := k8s.PVCsByLabels(ctx, r.Client, mysql.MatchLabels(cluster))
+	pvcs, err := k8s.PVCsByLabels(ctx, r.Client, mysql.MatchLabels(cluster), cluster.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "get PVC list")
 	}

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -338,10 +338,13 @@ func ObjectHash(obj runtime.Object) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
-func PodsByLabels(ctx context.Context, cl client.Reader, l map[string]string) ([]corev1.Pod, error) {
+func PodsByLabels(ctx context.Context, cl client.Reader, l map[string]string, namespace string) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
 
-	opts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(l)}
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(l),
+		Namespace:     namespace,
+	}
 	if err := cl.List(ctx, podList, opts); err != nil {
 		return nil, err
 	}
@@ -349,10 +352,13 @@ func PodsByLabels(ctx context.Context, cl client.Reader, l map[string]string) ([
 	return podList.Items, nil
 }
 
-func ServicesByLabels(ctx context.Context, cl client.Reader, l map[string]string) ([]corev1.Service, error) {
+func ServicesByLabels(ctx context.Context, cl client.Reader, l map[string]string, namespace string) ([]corev1.Service, error) {
 	svcList := &corev1.ServiceList{}
 
-	opts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(l)}
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(l),
+		Namespace:     namespace,
+	}
 	if err := cl.List(ctx, svcList, opts); err != nil {
 		return nil, err
 	}
@@ -360,10 +366,13 @@ func ServicesByLabels(ctx context.Context, cl client.Reader, l map[string]string
 	return svcList.Items, nil
 }
 
-func PVCsByLabels(ctx context.Context, cl client.Reader, l map[string]string) ([]corev1.PersistentVolumeClaim, error) {
+func PVCsByLabels(ctx context.Context, cl client.Reader, l map[string]string, namespace string) ([]corev1.PersistentVolumeClaim, error) {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 
-	opts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(l)}
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(l),
+		Namespace:     namespace,
+	}
 	if err := cl.List(ctx, pvcList, opts); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[![K8SPS-241](https://badgen.net/badge/JIRA/K8SPS-241/green)](https://jira.percona.com/browse/K8SPS-241) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Getting pods, PVCs, and services was done without specifying a namespace, only with labels, so everything was collected, from every namespace.

**Solution:**
Get all of these objects from a CR namespace.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-241]: https://perconadev.atlassian.net/browse/K8SPS-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ