### PR TITLE
K8SPS-373: reduce error logs on 1 mysql pod deployment

### DIFF
--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -804,12 +804,18 @@ func (r *PerconaServerMySQLReconciler) reconcileReplication(ctx context.Context,
 	}
 
 	if err := orchestrator.Discover(ctx, r.ClientCmd, pod, mysql.ServiceName(cr), mysql.DefaultPort); err != nil {
-		switch err.Error() {
-		case "Unauthorized":
+		switch {
+		case errors.Is(err, orchestrator.ErrUnauthorized):
 			log.Info("mysql is not ready, unauthorized orchestrator discover response. skip")
 			return nil
-		case orchestrator.ErrEmptyResponse.Error():
+		case errors.Is(err, orchestrator.ErrEmptyResponse):
 			log.Info("mysql is not ready, empty orchestrator discover response. skip")
+			return nil
+		case errors.Is(err, orchestrator.ErrBadConn):
+			log.Info("mysql is not ready, bad connection. skip")
+			return nil
+		case errors.Is(err, orchestrator.ErrNoSuchHost):
+			log.Info("mysql is not ready, host not found. skip")
 			return nil
 		}
 		return errors.Wrap(err, "failed to discover cluster")

--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -282,6 +282,9 @@ func (r *PerconaServerMySQLReconciler) isAsyncReady(ctx context.Context, cr *api
 
 	instances, err := orchestrator.Cluster(ctx, r.ClientCmd, pod, cr.ClusterHint())
 	if err != nil {
+		if errors.Is(err, orchestrator.ErrEmptyResponse) || errors.Is(err, orchestrator.ErrUnableToGetClusterName) {
+			return false, errors.Wrap(err, "orchestrator").Error(), nil
+		}
 		return false, "", err
 	}
 


### PR DESCRIPTION
[![K8SPS-373](https://badgen.net/badge/JIRA/K8SPS-373/green)](https://jira.percona.com/browse/K8SPS-373) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPS-373

**DESCRIPTION**
---
**Problem:**
_When using async cluster with 1 mysql pod, the operator prints the following error messages in the log:_
`
ERROR failed to update status {"controller": "ps-controller" ... "error": "check if async is ready: 2024-07-02 13:30:38 ERROR Unable to determine cluster name. clusterHint=cluster1.psasync" ...
`
_and_
`
ERROR failed to update status {"controller": "ps-controller" ... "error": "check if async is ready: unexpected end of JSON input" ...
`

**Cause:**
*During cluster deployment, the orchestrator is not ready at the same time as the mysql pod is deployed. It responds with an empty body, which is the cause of the `unexpected end of JSON input` error, or the `Unable to determine cluster name` error.*

**Solution:**
*Check for these errors and print the info messages `INFO Async replication not ready: orchestrator: unable to determine cluster name` or `INFO Async replication not ready: orchestrator: empty response`. We do the same checks in other parts of the operator code, we just need to add these missing checks to the `isAsyncReady` method: https://github.com/percona/percona-server-mysql-operator/pull/717/commits/0b23ce8d913112a74f8bfbe6dd6c146f92d19a54*

This PR also fixes [`K8SPS-369`](https://perconadev.atlassian.net/browse/K8SPS-369). The orchestrator returns `driver: bad connection` and `dial tcp: lookup cluster1-mysql-1.cluster1-mysql.default on X.X.X.X:53: no such host` errors when attempting to connect to a deleted mysql pod. The operator should check for this kind of errors and print `INFO` messages instead: https://github.com/percona/percona-server-mysql-operator/pull/717/commits/70c481f62384dd92f47a1121a11f6f014016a9a3

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-373]: https://perconadev.atlassian.net/browse/K8SPS-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ