### PR TITLE
K8SPS-350: Remove SSLInternalSecretName option

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -44,24 +44,23 @@ import (
 
 // PerconaServerMySQLSpec defines the desired state of PerconaServerMySQL
 type PerconaServerMySQLSpec struct {
-	CRVersion             string                               `json:"crVersion,omitempty"`
-	Pause                 bool                                 `json:"pause,omitempty"`
-	SecretsName           string                               `json:"secretsName,omitempty"`
-	SSLSecretName         string                               `json:"sslSecretName,omitempty"`
-	SSLInternalSecretName string                               `json:"sslInternalSecretName,omitempty"`
-	Unsafe                UnsafeFlags                          `json:"unsafeFlags,omitempty"`
-	InitImage             string                               `json:"initImage,omitempty"`
-	IgnoreAnnotations     []string                             `json:"ignoreAnnotations,omitempty"`
-	IgnoreLabels          []string                             `json:"ignoreLabels,omitempty"`
-	MySQL                 MySQLSpec                            `json:"mysql,omitempty"`
-	Orchestrator          OrchestratorSpec                     `json:"orchestrator,omitempty"`
-	PMM                   *PMMSpec                             `json:"pmm,omitempty"`
-	Backup                *BackupSpec                          `json:"backup,omitempty"`
-	Proxy                 ProxySpec                            `json:"proxy,omitempty"`
-	TLS                   *TLSSpec                             `json:"tls,omitempty"`
-	Toolkit               *ToolkitSpec                         `json:"toolkit,omitempty"`
-	UpgradeOptions        UpgradeOptions                       `json:"upgradeOptions,omitempty"`
-	UpdateStrategy        appsv1.StatefulSetUpdateStrategyType `json:"updateStrategy,omitempty"`
+	CRVersion         string                               `json:"crVersion,omitempty"`
+	Pause             bool                                 `json:"pause,omitempty"`
+	SecretsName       string                               `json:"secretsName,omitempty"`
+	SSLSecretName     string                               `json:"sslSecretName,omitempty"`
+	Unsafe            UnsafeFlags                          `json:"unsafeFlags,omitempty"`
+	InitImage         string                               `json:"initImage,omitempty"`
+	IgnoreAnnotations []string                             `json:"ignoreAnnotations,omitempty"`
+	IgnoreLabels      []string                             `json:"ignoreLabels,omitempty"`
+	MySQL             MySQLSpec                            `json:"mysql,omitempty"`
+	Orchestrator      OrchestratorSpec                     `json:"orchestrator,omitempty"`
+	PMM               *PMMSpec                             `json:"pmm,omitempty"`
+	Backup            *BackupSpec                          `json:"backup,omitempty"`
+	Proxy             ProxySpec                            `json:"proxy,omitempty"`
+	TLS               *TLSSpec                             `json:"tls,omitempty"`
+	Toolkit           *ToolkitSpec                         `json:"toolkit,omitempty"`
+	UpgradeOptions    UpgradeOptions                       `json:"upgradeOptions,omitempty"`
+	UpdateStrategy    appsv1.StatefulSetUpdateStrategyType `json:"updateStrategy,omitempty"`
 }
 
 type UnsafeFlags struct {

--- a/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
+++ b/config/crd/bases/ps.percona.com_perconaservermysqls.yaml
@@ -7570,8 +7570,6 @@ spec:
                 type: object
               secretsName:
                 type: string
-              sslInternalSecretName:
-                type: string
               sslSecretName:
                 type: string
               tls:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -9466,8 +9466,6 @@ spec:
                 type: object
               secretsName:
                 type: string
-              sslInternalSecretName:
-                type: string
               sslSecretName:
                 type: string
               tls:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -9466,8 +9466,6 @@ spec:
                 type: object
               secretsName:
                 type: string
-              sslInternalSecretName:
-                type: string
               sslSecretName:
                 type: string
               tls:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -9466,8 +9466,6 @@ spec:
                 type: object
               secretsName:
                 type: string
-              sslInternalSecretName:
-                type: string
               sslSecretName:
                 type: string
               tls:


### PR DESCRIPTION
[![K8SPS-350](https://badgen.net/badge/JIRA/K8SPS-350/green)](https://jira.percona.com/browse/K8SPS-350) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We had `SSLInternalSecretName` in our CR but is not used and we don't need it. This PR removes it.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-350]: https://perconadev.atlassian.net/browse/K8SPS-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ