### PR TITLE
K8SPS-388: fix resources amount when resource quota is enabled

### DIFF
--- a/pkg/binlogserver/binlog_server.go
+++ b/pkg/binlogserver/binlog_server.go
@@ -86,6 +86,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL, initImage, configHash strin
 							initImage,
 							spec.ImagePullPolicy,
 							spec.ContainerSecurityContext,
+							spec.Resources,
 						),
 					},
 					Containers:                    containers(cr),

--- a/pkg/haproxy/haproxy.go
+++ b/pkg/haproxy/haproxy.go
@@ -172,6 +172,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL, initImage, configHash, tlsH
 							initImage,
 							cr.Spec.Proxy.HAProxy.ImagePullPolicy,
 							cr.Spec.Proxy.HAProxy.ContainerSecurityContext,
+							cr.Spec.Proxy.HAProxy.Resources,
 						),
 					},
 					Containers:                containers(cr, secret),

--- a/pkg/k8s/init_image.go
+++ b/pkg/k8s/init_image.go
@@ -16,7 +16,7 @@ type ComponentWithInit interface {
 	GetInitImage() string
 }
 
-func InitContainer(component, image string, pullPolicy corev1.PullPolicy, secCtx *corev1.SecurityContext) corev1.Container {
+func InitContainer(component, image string, pullPolicy corev1.PullPolicy, secCtx *corev1.SecurityContext, resList corev1.ResourceRequirements) corev1.Container {
 	return corev1.Container{
 		Name:            component + "-init",
 		Image:           image,
@@ -31,6 +31,7 @@ func InitContainer(component, image string, pullPolicy corev1.PullPolicy, secCtx
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		SecurityContext:          secCtx,
+		Resources:                resList,
 	}
 }
 

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -163,6 +163,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL, initImage, configHash, tlsH
 							initImage,
 							spec.ImagePullPolicy,
 							spec.ContainerSecurityContext,
+							spec.Resources,
 						),
 					},
 					Containers:                    containers(cr, secret),
@@ -596,6 +597,7 @@ func backupContainer(cr *apiv1alpha1.PerconaServerMySQL) corev1.Container {
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		SecurityContext:          cr.Spec.Backup.ContainerSecurityContext,
+		Resources:                cr.Spec.Backup.Resources,
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -145,6 +145,7 @@ func StatefulSet(cr *apiv1alpha1.PerconaServerMySQL, initImage, tlsHash string) 
 							initImage,
 							spec.ImagePullPolicy,
 							spec.ContainerSecurityContext,
+							spec.Resources,
 						),
 					},
 					NodeSelector:                  cr.Spec.Orchestrator.NodeSelector,

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -181,6 +181,7 @@ func Deployment(cr *apiv1alpha1.PerconaServerMySQL, initImage, configHash, tlsHa
 							initImage,
 							spec.ImagePullPolicy,
 							spec.ContainerSecurityContext,
+							spec.Resources,
 						),
 					},
 					Containers:                    containers(cr),

--- a/pkg/xtrabackup/xtrabackup.go
+++ b/pkg/xtrabackup/xtrabackup.go
@@ -141,6 +141,7 @@ func Job(
 							initImage,
 							cluster.Spec.Backup.ImagePullPolicy,
 							storage.ContainerSecurityContext,
+							cluster.Spec.Backup.Resources,
 						),
 					},
 					Containers: []corev1.Container{


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Explained in this issue https://github.com/percona/percona-helm-charts/issues/460

**Cause:**
init containers and xtrabackup container do not have ResourceRequirments.

**Solution:**
Add ResourceRequirments for InitContainer and add Resource to Backup spec.

**CHECKLIST**
---
**Jira**
- [x ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
