### PR TITLE
K8SPS-392: add validation for `BOOTSTRAP_READ_TIMEOUT` in reconciler

### DIFF
--- a/api/v1alpha1/perconaservermysql_types.go
+++ b/api/v1alpha1/perconaservermysql_types.go
@@ -22,6 +22,7 @@ import (
 	"hash/fnv"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -802,6 +803,19 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(_ context.Context, serverVersion
 
 		if cr.RouterEnabled() {
 			return errors.New("MySQL Router can't be enabled for asynchronous replication")
+		}
+
+		for _, env := range cr.Spec.MySQL.Env {
+			if env.Name != naming.EnvBootstrapReadTimeout {
+				continue
+			}
+			readTimeout, err := strconv.Atoi(env.Value)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse BOOTSTRAP_READ_TIMEOUT")
+			}
+			if readTimeout < 0 {
+				return errors.New("BOOTSTRAP_READ_TIMEOUT should be a positive value")
+			}
 		}
 	}
 


### PR DESCRIPTION
[![K8SPS-392](https://badgen.net/badge/JIRA/K8SPS-392/green)](https://jira.percona.com/browse/K8SPS-392) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPS-392

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-392]: https://perconadev.atlassian.net/browse/K8SPS-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ