### PR TITLE
Increase monitoring test timeout

### DIFF
--- a/e2e-tests/tests/monitoring/01-deploy-pmm-server.yaml
+++ b/e2e-tests/tests/monitoring/01-deploy-pmm-server.yaml
@@ -8,8 +8,7 @@ commands:
       source ../../functions
 
       deploy_pmm_server
-      sleep 60 # wait for PMM Server to start
-
+      sleep 120 # wait for PMM Server to start
       TOKEN=$(get_pmm_server_token)
       kubectl patch -n "${NAMESPACE}" secret test-secrets --type merge --patch "$(jq -n --arg token "$TOKEN" '{"stringData": {"pmmservertoken": $token}}')"
-    timeout: 120
+    timeout: 240


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Sometimes PMM takes more time to be deployed, so monitoring test fails.

**Solution:**
Increase wait time and timeouts

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
