### PR TITLE
K8SPS-398: Replace assert with readiness check for chaos-daemon

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -780,14 +780,19 @@ deploy_chaos_mesh() {
 
 	helm repo add chaos-mesh https://charts.chaos-mesh.org
 	if [ -n "${MINIKUBE}" ]; then
-		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=${NAMESPACE} --set chaosDaemon.runtime=docker --set dashboard.create=false --version ${CHAOS_MESH_VER}
+		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=${NAMESPACE} --set chaosDaemon.runtime=docker --set dashboard.create=false --version ${CHAOS_MESH_VER} --wait
 	else
-		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=${NAMESPACE} --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --set dashboard.create=false --version ${CHAOS_MESH_VER}
+		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=${NAMESPACE} --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --set dashboard.create=false --version ${CHAOS_MESH_VER} --wait
 	fi
 	if [[ -n $OPENSHIFT ]]; then
 		oc adm policy add-scc-to-user privileged -z chaos-daemon --namespace=${NAMESPACE}
 	fi
-	sleep 10
+
+	echo "Waiting for chaos-mesh DaemonSet to be ready..."
+    until [ "$(kubectl get daemonset chaos-daemon -n ${NAMESPACE} -o jsonpath='{.status.numberReady}')" = "$(kubectl get daemonset chaos-daemon -n ${NAMESPACE} -o jsonpath='{.status.desiredNumberScheduled}')" ]; do
+        echo "Waiting for DaemonSet chaos-daemon..."
+        sleep 5
+    done
 }
 
 destroy_chaos_mesh() {

--- a/e2e-tests/tests/gr-self-healing/01-assert.yaml
+++ b/e2e-tests/tests/gr-self-healing/01-assert.yaml
@@ -13,16 +13,3 @@ status:
   readyReplicas: 3
   replicas: 3
   updatedReplicas: 3
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: chaos-daemon
-status:
-  currentNumberScheduled: 3
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  numberMisscheduled: 0
-  numberReady: 3
-  observedGeneration: 1
-  updatedNumberScheduled: 3

--- a/e2e-tests/tests/operator-self-healing/02-assert.yaml
+++ b/e2e-tests/tests/operator-self-healing/02-assert.yaml
@@ -59,15 +59,3 @@ status:
     state: ready
   state: ready
 ---
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: chaos-daemon
-status:
-  currentNumberScheduled: 3
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  numberMisscheduled: 0
-  numberReady: 3
-  observedGeneration: 1
-  updatedNumberScheduled: 3


### PR DESCRIPTION
[![K8SPS-398](https://badgen.net/badge/JIRA/K8SPS-398/green)](https://jira.percona.com/browse/K8SPS-398) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPS-396

**CHANGE DESCRIPTION**
---
**Problem:**
The assert of chaos-mesh DaemonSet was considering just 3 node clusters, so it failed when deployed in 3+ node clusters.

**Solution:**
Replace asserts with readiness check.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-398]: https://perconadev.atlassian.net/browse/K8SPS-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ