### PR TITLE
K8SPS-126 Added volumeExpansion option to CR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,7 +375,7 @@ pipeline {
         ENABLE_LOGGING = "true"
     }
     agent {
-        label 'docker'
+        label 'docker-x64-min'
     }
     options {
         disableConcurrentBuilds(abortPrevious: true)
@@ -530,7 +530,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -545,7 +545,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -560,7 +560,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -575,7 +575,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -590,7 +590,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -605,7 +605,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()
@@ -620,7 +620,7 @@ pipeline {
                         }
                     }
                     agent {
-                        label 'docker'
+                        label 'docker-x64-min'
                     }
                     steps {
                         prepareNode()

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -15,6 +15,7 @@ spec:
 #    proxySize: false
 #  pause: false
   crVersion: 0.11.0
+#  enableVolumeExpansion: false
   secretsName: cluster1-secrets
   sslSecretName: cluster1-ssl
   updateStrategy: SmartUpdate


### PR DESCRIPTION
[![K8SPS-126](https://badgen.net/badge/JIRA/K8SPS-126/green)](https://jira.percona.com/browse/K8SPS-126) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We have added a code for automatic storage change via volume expansion but the option in CR is missing which is confusing.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
This PR adds the enableVolumeExpansion option to CR, following previously made code changes


**CHECKLIST**
---
**Jira**
- [+ ] Is the Jira ticket created and referenced properly?
- [+ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [+ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-126]: https://perconadev.atlassian.net/browse/K8SPS-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ