### PR TITLE
K8SPS-269 fix labels for orchestrator

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -453,7 +453,7 @@ func PodService(cr *apiv1alpha1.PerconaServerMySQL, t corev1.ServiceType, podNam
 }
 
 func ConfigMap(cr *apiv1alpha1.PerconaServerMySQL, data map[string]string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
@@ -466,6 +466,17 @@ func ConfigMap(cr *apiv1alpha1.PerconaServerMySQL, data map[string]string) *core
 		},
 		Data: data,
 	}
+	if cr.CompareVersion("0.12.0") >= 0 {
+		if cm.Labels == nil {
+			cm.Labels = map[string]string{}
+		}
+		for k, v := range naming.Labels(ConfigMapName(cr), cr.Name, "percona-server", "orchestrator") {
+			if _, exists := cm.Labels[k]; !exists { // global labels have priority
+				cm.Labels[k] = v
+			}
+		}
+	}
+	return cm
 }
 
 func RaftNodes(cr *apiv1alpha1.PerconaServerMySQL) []string {


### PR DESCRIPTION
[![K8SPS-269](https://badgen.net/badge/JIRA/K8SPS-269/green)](https://jira.percona.com/browse/K8SPS-269) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
For the orchestrator we have a separate method that creates a ConfigMap, so we’ll need to update that as well. In this PR I’d also like to discuss whether it makes sense to merge the two methods into one.

I checked labels for haproxy, router and orchestrator. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-269]: https://perconadev.atlassian.net/browse/K8SPS-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ