### PR TITLE
K8SPS-339: fix using dataSource for gr cluster

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -176,7 +176,7 @@ spec:
 #        accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
-            storage: 2G
+            storage: 2Gi
     gracePeriod: 600
 #    configuration: |
 #      max_connections=250
@@ -207,7 +207,7 @@ spec:
 #      spec:
 #        resources:
 #          requests:
-#            storage: 1G
+#            storage: 1Gi
 #    containerSecurityContext:
 #      privileged: true
 #    podSecurityContext:

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -1,11 +1,12 @@
-version-service
+async-data-at-rest-encryption
+async-data-source
 async-ignore-annotations
 auto-config
 config
 config-router
 demand-backup
-async-data-at-rest-encryption
 gr-data-at-rest-encryption
+gr-data-source
 gr-demand-backup
 gr-demand-backup-haproxy
 gr-finalizer
@@ -26,6 +27,7 @@ limits
 monitoring
 one-pod
 operator-self-healing
+pvc-resize
 recreate
 scaling
 scheduled-backup
@@ -35,4 +37,4 @@ smart-update
 storage
 tls-cert-manager
 users
-pvc-resize
+version-service

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -1,11 +1,12 @@
-version-service
+async-data-at-rest-encryption
+async-data-source
 async-ignore-annotations
 auto-config
 config
 config-router
 demand-backup
-async-data-at-rest-encryption
 gr-data-at-rest-encryption
+gr-data-source
 gr-demand-backup
 gr-demand-backup-haproxy
 gr-finalizer
@@ -26,6 +27,7 @@ limits
 monitoring
 one-pod
 operator-self-healing
+pvc-resize
 recreate
 scaling
 scheduled-backup
@@ -35,4 +37,4 @@ smart-update
 storage
 tls-cert-manager
 users
-pvc-resize
+version-service

--- a/e2e-tests/tests/async-data-source/09-delete-cluster.yaml
+++ b/e2e-tests/tests/async-data-source/09-delete-cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      kubectl delete ps -n "${NAMESPACE}" async-data-source

--- a/e2e-tests/tests/async-data-source/10-assert.yaml
+++ b/e2e-tests/tests/async-data-source/10-assert.yaml
@@ -1,0 +1,60 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: async-data-source-ref-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: async-data-source-ref-orc
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: async-data-source-ref-haproxy
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: async-data-source-ref
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+status:
+  haproxy:
+    ready: 3
+    size: 3
+    state: ready
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  orchestrator:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready

--- a/e2e-tests/tests/async-data-source/10-create-cluster-dataSourceRef.yaml
+++ b/e2e-tests/tests/async-data-source/10-create-cluster-dataSourceRef.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      suffix="ref"
+      get_cr $suffix \
+          | yq eval '.spec.secretsName="internal-async-data-source-initial"' - \
+          | yq eval '.spec.mysql.clusterType="async"' - \
+          | yq eval '.spec.mysql.size=3' - \
+          | yq eval '.spec.proxy.haproxy.enabled=true' - \
+          | yq eval '.spec.proxy.haproxy.size=3' - \
+          | yq eval '.spec.orchestrator.enabled=true' - \
+          | yq eval '.spec.orchestrator.size=3' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.resources.requests.storage="3Gi"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSourceRef.kind="PersistentVolumeClaim"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSourceRef.name="datadir-async-data-source-initial-mysql-0"' - \
+          | kubectl -n "${NAMESPACE}" apply -f -
+    timeout: 180

--- a/e2e-tests/tests/async-data-source/11-assert.yaml
+++ b/e2e-tests/tests/async-data-source/11-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 11-read-from-primary
+data:
+  data: "100500"

--- a/e2e-tests/tests/async-data-source/11-read-from-primary.yaml
+++ b/e2e-tests/tests/async-data-source/11-read-from-primary.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      data=$(run_mysql "SELECT * FROM myDB.myTable" "-h $(get_haproxy_svc $(get_cluster_name)) -uroot -proot_password")
+
+      kubectl create configmap -n "${NAMESPACE}" 11-read-from-primary --from-literal=data="${data}"

--- a/e2e-tests/tests/async-data-source/12-assert.yaml
+++ b/e2e-tests/tests/async-data-source/12-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 12-read-from-replicas
+data:
+  async-data-source-ref-mysql-0.async-data-source-ref-mysql: "100500"
+  async-data-source-ref-mysql-1.async-data-source-ref-mysql: "100500"
+  async-data-source-ref-mysql-2.async-data-source-ref-mysql: "100500"

--- a/e2e-tests/tests/async-data-source/12-read-from-replicas.yaml
+++ b/e2e-tests/tests/async-data-source/12-read-from-replicas.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      args=''
+      size=$(kubectl -n ${NAMESPACE} get ps $(get_cluster_name) -o jsonpath='{.spec.mysql.size}')
+      for i in $(seq 0 $((size - 1))); do
+          host=$(get_mysql_headless_fqdn $(get_cluster_name) $i)
+          data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${host} -uroot -proot_password")
+          args="${args} --from-literal=${host}=${data}"
+      done
+
+      kubectl create configmap -n "${NAMESPACE}" 12-read-from-replicas ${args}

--- a/e2e-tests/tests/gr-data-source/00-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/00-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermysqls.ps.percona.com
+spec:
+  group: ps.percona.com
+  names:
+    kind: PerconaServerMySQL
+    listKind: PerconaServerMySQLList
+    plural: perconaservermysqls
+    shortNames:
+    - ps
+    singular: perconaservermysql
+  scope: Namespaced
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: check-operator-deploy-status
+timeout: 120
+commands:
+  - script: kubectl assert exist-enhanced deployment percona-server-mysql-operator -n ${OPERATOR_NS:-$NAMESPACE} --field-selector status.readyReplicas=1

--- a/e2e-tests/tests/gr-data-source/00-deploy-operator.yaml
+++ b/e2e-tests/tests/gr-data-source/00-deploy-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+      init_temp_dir # do this only in the first TestStep
+
+      deploy_operator
+      deploy_non_tls_cluster_secrets
+      deploy_tls_cluster_secrets
+      deploy_client

--- a/e2e-tests/tests/gr-data-source/01-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/01-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-initial-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-initial-router
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  availableReplicas: 3
+  updatedReplicas: 3
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-data-source-initial
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+status:
+  router:
+    ready: 3
+    size: 3
+    state: ready
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-data-source/01-create-cluster.yaml
+++ b/e2e-tests/tests/gr-data-source/01-create-cluster.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      suffix="initial"
+
+      get_cr $suffix \
+          | yq eval '.spec.mysql.clusterType="group-replication"' - \
+          | yq eval '.spec.proxy.router.enabled=true' - \
+          | yq eval '.spec.proxy.haproxy.enabled=false' - \
+          | yq eval '.spec.mysql.size=3' - \
+          | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/gr-data-source/02-write-data.yaml
+++ b/e2e-tests/tests/gr-data-source/02-write-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o pipefail
+      set -o xtrace
+
+      source ../../functions
+
+      password=$(get_user_pass root)
+      run_mysql \
+          "CREATE DATABASE IF NOT EXISTS myDB; CREATE TABLE IF NOT EXISTS myDB.myTable (id int PRIMARY KEY)" \
+          "-h $(get_mysql_router_service $(get_cluster_name)) -uroot -p'$password'"
+
+      run_mysql \
+          "INSERT myDB.myTable (id) VALUES (100500)" \
+          "-h $(get_mysql_router_service $(get_cluster_name)) -uroot -p'$password'"

--- a/e2e-tests/tests/gr-data-source/03-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/03-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 03-read-data-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 03-read-data-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 03-read-data-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/gr-data-source/03-read-data.yaml
+++ b/e2e-tests/tests/gr-data-source/03-read-data.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      password=$(get_user_pass root)
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2; do
+          data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -p'$password'")
+          kubectl create configmap -n "${NAMESPACE}" 03-read-data-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/gr-data-source/04-delete-cluster.yaml
+++ b/e2e-tests/tests/gr-data-source/04-delete-cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      kubectl delete ps -n "${NAMESPACE}" gr-data-source-initial

--- a/e2e-tests/tests/gr-data-source/05-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/05-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-router
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  availableReplicas: 3
+  updatedReplicas: 3
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-data-source
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+status:
+  router:
+    ready: 3
+    size: 3
+    state: ready
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-data-source/05-create-cluster-with-dataSource.yaml
+++ b/e2e-tests/tests/gr-data-source/05-create-cluster-with-dataSource.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      get_cr \
+          | yq eval '.spec.mysql.clusterType="group-replication"' - \
+          | yq eval '.spec.proxy.router.enabled=true' - \
+          | yq eval '.spec.proxy.haproxy.enabled=false' - \
+          | yq eval '.spec.mysql.size=3' - \
+          | yq eval '.spec.secretsName="internal-gr-data-source-initial"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.resources.requests.storage="3Gi"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSource.kind="PersistentVolumeClaim"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSource.name="datadir-gr-data-source-initial-mysql-0"' - \
+          | kubectl -n "${NAMESPACE}" apply -f -
+    timeout: 180

--- a/e2e-tests/tests/gr-data-source/06-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/06-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 06-read-data-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/gr-data-source/06-read-data.yaml
+++ b/e2e-tests/tests/gr-data-source/06-read-data.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      password=$(get_user_pass root)
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2; do
+          data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -p'$password'")
+          kubectl create configmap -n "${NAMESPACE}" 06-read-data-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/gr-data-source/07-delete-cluster.yaml
+++ b/e2e-tests/tests/gr-data-source/07-delete-cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      kubectl delete ps -n "${NAMESPACE}" gr-data-source

--- a/e2e-tests/tests/gr-data-source/08-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/08-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-ref-mysql
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  currentReplicas: 3
+  updatedReplicas: 3
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gr-data-source-ref-router
+status:
+  observedGeneration: 1
+  replicas: 3
+  readyReplicas: 3
+  availableReplicas: 3
+  updatedReplicas: 3
+---
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-data-source-ref
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+status:
+  router:
+    ready: 3
+    size: 3
+    state: ready
+  mysql:
+    ready: 3
+    size: 3
+    state: ready
+  state: ready

--- a/e2e-tests/tests/gr-data-source/08-create-cluster-dataSourceRef.yaml
+++ b/e2e-tests/tests/gr-data-source/08-create-cluster-dataSourceRef.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      suffix="ref"
+      get_cr $suffix \
+          | yq eval '.spec.mysql.clusterType="group-replication"' - \
+          | yq eval '.spec.proxy.router.enabled=true' - \
+          | yq eval '.spec.proxy.haproxy.enabled=false' - \
+          | yq eval '.spec.mysql.size=3' - \
+          | yq eval '.spec.secretsName="internal-gr-data-source-initial"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.resources.requests.storage="3Gi"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSourceRef.kind="PersistentVolumeClaim"' - \
+          | yq eval '.spec.mysql.volumeSpec.persistentVolumeClaim.dataSourceRef.name="datadir-gr-data-source-initial-mysql-0"' - \
+          | kubectl -n "${NAMESPACE}" apply -f -
+    timeout: 180

--- a/e2e-tests/tests/gr-data-source/09-assert.yaml
+++ b/e2e-tests/tests/gr-data-source/09-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 09-read-data-0
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 09-read-data-1
+data:
+  data: "100500"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: 09-read-data-2
+data:
+  data: "100500"

--- a/e2e-tests/tests/gr-data-source/09-read-data.yaml
+++ b/e2e-tests/tests/gr-data-source/09-read-data.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      password=$(get_user_pass root)
+      cluster_name=$(get_cluster_name)
+      for i in 0 1 2; do
+          data=$(run_mysql "SELECT * FROM myDB.myTable" "-h ${cluster_name}-mysql-${i}.${cluster_name}-mysql -uroot -p'$password'")
+          kubectl create configmap -n "${NAMESPACE}" 09-read-data-${i} --from-literal=data="${data}"
+      done

--- a/e2e-tests/tests/gr-data-source/98-drop-finalizer.yaml
+++ b/e2e-tests/tests/gr-data-source/98-drop-finalizer.yaml
@@ -1,0 +1,5 @@
+apiVersion: ps.percona.com/v1alpha1
+kind: PerconaServerMySQL
+metadata:
+  name: gr-data-source
+  finalizers: []

--- a/e2e-tests/tests/gr-data-source/99-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/gr-data-source/99-remove-cluster-gracefully.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: ps.percona.com/v1alpha1
+    kind: PerconaServerMySQL
+    metadata:
+      name: gr-data-source
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      destroy_operator
+    timeout: 60

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -473,7 +473,7 @@ func (r *PerconaServerMySQLReconciler) doReconcile(
 		return errors.Wrap(err, "scheduled backup")
 	}
 	if err := r.reconcileDataSource(ctx, cr); err != nil {
-		return errors.Wrap(err, "scheduled backup")
+		return errors.Wrap(err, "reconcile data source")
 	}
 	if err := r.cleanupOutdated(ctx, cr); err != nil {
 		return errors.Wrap(err, "cleanup outdated")


### PR DESCRIPTION
[![K8SPS-339](https://badgen.net/badge/JIRA/K8SPS-339/green)](https://jira.percona.com/browse/K8SPS-339) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPS-339

**DESCRIPTION**
---
**Problem:**
*When using `dataSource` with `group-replication` cluster some pods fail to bootstrap.*

**Cause:**
*When using `dataSource`, all mysql pods share the same `/var/lib/mysql/auto.cnf` file and therefore have the same `server_uuid`. However they should each have a unique one.*

*Also, the metadata table contains the name of the previous cluster, which causes an error when the `dba.createCluster` is called.*

**Solution:**
*If bootstrap fails with the error `Cannot add an instance with the same server UUID`, the bootstrap binary should delete the `/var/lib/mysql/auto.cnf` file and restart the pod.*

*If it fails to connect to the cluster, it should compare the cluster name from the `INNODB_CLUSTER_NAME` env var with the `cluster_name` from the metadata schema. If they differ, the bootstrap binary should call `dba.dropMetadataSchema` and continue.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-339]: https://perconadev.atlassian.net/browse/K8SPS-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ