### PR TITLE
K8SPS-400 and K8SPS-527 fixes

### DIFF
--- a/pkg/controller/psbackup/controller.go
+++ b/pkg/controller/psbackup/controller.go
@@ -235,7 +235,6 @@ func (r *PerconaServerMySQLBackupReconciler) Reconcile(ctx context.Context, req 
 }
 
 func (r *PerconaServerMySQLBackupReconciler) isBackupJobRunning(ctx context.Context, job *batchv1.Job) (bool, error) {
-	log := logf.FromContext(ctx)
 	if len(job.Spec.Template.Spec.Containers) == 0 {
 		return false, nil
 	}
@@ -258,7 +257,6 @@ func (r *PerconaServerMySQLBackupReconciler) isBackupJobRunning(ctx context.Cont
 	}
 
 	if cfg == nil || cfg.Destination != destination {
-		log.Error(fmt.Errorf("running backup destination does not match expected or config is nil"), "expected destination", "destination", destination)
 		return false, nil
 	}
 

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -748,7 +748,7 @@ func backupVolumeMounts(cr *apiv1.PerconaServerMySQL) []corev1.VolumeMount {
 }
 
 func backupContainer(cr *apiv1.PerconaServerMySQL) corev1.Container {
-	return corev1.Container{
+	container := corev1.Container{
 		Name:            "xtrabackup",
 		Image:           cr.Spec.Backup.Image,
 		ImagePullPolicy: cr.Spec.Backup.ImagePullPolicy,
@@ -766,6 +766,15 @@ func backupContainer(cr *apiv1.PerconaServerMySQL) corev1.Container {
 		SecurityContext:          cr.Spec.Backup.ContainerSecurityContext,
 		Resources:                cr.Spec.Backup.Resources,
 	}
+
+	if cr.CompareVersion("0.12.0") >= 0 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "CLUSTER_TYPE",
+			Value: string(cr.Spec.MySQL.ClusterType),
+		})
+	}
+
+	return container
 }
 
 func heartbeatContainer(cr *apiv1.PerconaServerMySQL) corev1.Container {


### PR DESCRIPTION
[![K8SPS-400](https://badgen.net/badge/JIRA/K8SPS-400/green)](https://jira.percona.com/browse/K8SPS-400) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---

This PR addresses two problems:
1. Xtrabackup sidecar attempts to restart SQL thread on failure even if cluster uses group replication.
2. Unnecessary error log during backups.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-400]: https://perconadev.atlassian.net/browse/K8SPS-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ