### PR TITLE
K8SPS-417: Fix setting blockOwnerDeletion for PDB on Openshift

### DIFF
--- a/config/rbac/cluster/role.yaml
+++ b/config/rbac/cluster/role.yaml
@@ -98,6 +98,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,6 +98,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -13349,6 +13349,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -13349,6 +13349,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/deploy/cw-rbac.yaml
+++ b/deploy/cw-rbac.yaml
@@ -139,6 +139,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -139,6 +139,7 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
   verbs:
   - create
   - get

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -73,18 +73,17 @@ type PerconaServerMySQLReconciler struct {
 	Crons         CronRegistry
 }
 
-//+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqls;perconaservermysqls/status;perconaservermysqls/finalizers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps;services;secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=pods;pods/exec,verbs=get;list;watch;create;update;patch;delete;deletecollection
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;get;list;patch;update;watch
-//+kubebuilder:rbac:groups=apps,resources=statefulsets;deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=certmanager.k8s.io;cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;patch
-//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
-//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups=apps,resources=statefulsets;deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets;poddisruptionbudgets/finalizers,verbs=create;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=certmanager.k8s.io;cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqls;perconaservermysqls/status;perconaservermysqls/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PerconaServerMySQLReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
[![K8SPS-417](https://badgen.net/badge/JIRA/K8SPS-417/green)](https://jira.percona.com/browse/K8SPS-417) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
```
2025-09-12T20:53:23.164Z        ERROR   Reconciler error        {"controller": "ps-controller", "controllerGroup": "ps.percona.com", "controllerKind": "PerconaServerMySQL", "PerconaServerMySQL": {"name":"ps-cluster1","namespace":"test"}, "namespace": "test", "name": "ps-cluster1", "reconcileID": "81936cc6-35b3-4e00-987e-62fd5aa486ba", "error": "reconcile: database: ensure component: failed to create pdb: create test/ps-cluster1-mysql: poddisruptionbudgets.policy \"ps-cluster1-mysql\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>", "errorVerbose": "poddisruptionbudgets.policy \"ps-cluster1-mysql\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>\ncreate test/ps-cluster1-mysql\ngithub.com/percona/percona-server-mysql-operator/pkg/k8s.EnsureObjectWithHash\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/k8s/utils.go:215\ngithub.com/percona/percona-server-mysql-operator/pkg/k8s.EnsureComponent\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/k8s/utils.go:304\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-417]: https://perconadev.atlassian.net/browse/K8SPS-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ