### PR TITLE
K8SPS-417: Fix owner of PDB

### DIFF
--- a/e2e-tests/tests/init-deploy/01-assert.yaml
+++ b/e2e-tests/tests/init-deploy/01-assert.yaml
@@ -76,11 +76,11 @@ metadata:
     app.kubernetes.io/part-of: percona-server
   name: init-deploy-haproxy
   ownerReferences:
-  - apiVersion: apps/v1
+  - apiVersion: ps.percona.com/v1
     blockOwnerDeletion: true
     controller: true
-    kind: StatefulSet
-    name: init-deploy-haproxy
+    kind: PerconaServerMySQL
+    name: init-deploy
 spec:
   minAvailable: 1
   selector:
@@ -115,11 +115,11 @@ metadata:
     app.kubernetes.io/part-of: percona-server
   name: init-deploy-mysql
   ownerReferences:
-  - apiVersion: apps/v1
+  - apiVersion: ps.percona.com/v1
     blockOwnerDeletion: true
     controller: true
-    kind: StatefulSet
-    name: init-deploy-mysql
+    kind: PerconaServerMySQL
+    name: init-deploy
 spec:
   maxUnavailable: 1
   selector:
@@ -154,11 +154,11 @@ metadata:
     app.kubernetes.io/part-of: percona-server
   name: init-deploy-orchestrator
   ownerReferences:
-  - apiVersion: apps/v1
+  - apiVersion: ps.percona.com/v1
     blockOwnerDeletion: true
     controller: true
-    kind: StatefulSet
-    name: init-deploy-orc
+    kind: PerconaServerMySQL
+    name: init-deploy
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -301,7 +301,7 @@ func EnsureComponent(
 	}
 
 	pdb := podDisruptionBudget(cr, podSpec.PodDisruptionBudget, c.Labels(), c.MatchLabels())
-	if err := EnsureObjectWithHash(ctx, cl, obj, pdb, cl.Scheme()); err != nil {
+	if err := EnsureObjectWithHash(ctx, cl, cr, pdb, cl.Scheme()); err != nil {
 		return errors.Wrap(err, "failed to create pdb")
 	}
 


### PR DESCRIPTION
[![K8SPS-417](https://badgen.net/badge/JIRA/K8SPS-417/green)](https://jira.percona.com/browse/K8SPS-417) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
```
2025-09-12T20:53:23.164Z        ERROR   Reconciler error        {"controller": "ps-controller", "controllerGroup": "ps.percona.com", "controllerKind": "PerconaServerMySQL", "PerconaServerMySQL": {"name":"ps-cluster1","namespace":"test"}, "namespace": "test", "name": "ps-cluster1", "reconcileID": "81936cc6-35b3-4e00-987e-62fd5aa486ba", "error": "reconcile: database: ensure component: failed to create pdb: create test/ps-cluster1-mysql: poddisruptionbudgets.policy \"ps-cluster1-mysql\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>", "errorVerbose": "poddisruptionbudgets.policy \"ps-cluster1-mysql\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>\ncreate test/ps-cluster1-mysql\ngithub.com/percona/percona-server-mysql-operator/pkg/k8s.EnsureObjectWithHash\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/k8s/utils.go:215\ngithub.com/percona/percona-server-mysql-operator/pkg/k8s.EnsureComponent\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/k8s/utils.go:304\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-417]: https://perconadev.atlassian.net/browse/K8SPS-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ