### PR TITLE
K8SPS-393 check sts generation before and after rotating the pmm3 token

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1437,3 +1437,22 @@ get_telemetry_report_by_id() {
 		sleep 5
 	done
 }
+
+wait_for_generation() {
+	local resource="$1"
+	local target_generation="$2"
+
+	echo "Waiting for $resource to reach generation $target_generation..."
+
+	while true; do
+		current_generation=$(kubectl -n ${NAMESPACE} get "$resource" -o jsonpath='{.metadata.generation}')
+
+		if [ "$current_generation" -eq "$target_generation" ]; then
+			echo "Resource $resource has reached generation $target_generation."
+			break
+		else
+			echo "Resource $resource is at generation $current_generation. Waiting..."
+			sleep 5
+		fi
+	done
+}

--- a/e2e-tests/tests/monitoring/03-rotate-pmm-token.yaml
+++ b/e2e-tests/tests/monitoring/03-rotate-pmm-token.yaml
@@ -7,11 +7,19 @@ commands:
 
       source ../../functions
 
+      wait_for_generation "sts/monitoring-mysql" 1
+      wait_for_generation "sts/monitoring-haproxy" 1
+
       # add new PMM API token to secret
       NEW_TOKEN=$(get_pmm_server_token "operator-new")
       kubectl patch -n "${NAMESPACE}" secret test-secrets --type merge --patch "$(jq -n --arg token "$NEW_TOKEN" '{"stringData": {"pmmservertoken": $token}}')"
 
       # delete old PMM token
       delete_pmm_server_token "operator"
+
       sleep 10
+
+      wait_for_generation "sts/monitoring-mysql" 2
+      wait_for_generation "sts/monitoring-haproxy" 2
+
     timeout: 120


### PR DESCRIPTION
[![K8SPS-393](https://badgen.net/badge/JIRA/K8SPS-393/green)](https://jira.percona.com/browse/K8SPS-393) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

On the existing e2e test for PMM3, when we are rotating the token, we need to ensure that the instance statefulsets are updated properly so that new pods are rolled out. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-393]: https://perconadev.atlassian.net/browse/K8SPS-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ