### PR TITLE
K8SPS-510: use 500Mi limit for PS operator deployment

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -13484,7 +13484,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -13494,7 +13494,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/deploy/cw-operator.yaml
+++ b/deploy/cw-operator.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -69,7 +69,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
