### PR TITLE
K8SPS-469 fix `data-at-rest` tests

### DIFF
--- a/build/run-restore.sh
+++ b/build/run-restore.sh
@@ -3,7 +3,7 @@
 set -e
 set -o xtrace
 
-XTRABACKUP_VERSION=$(xtrabackup --version 2>&1 | awk '/^xtrabackup version/{print $3}'| awk -F'.' '{print $1"."$2}')
+XTRABACKUP_VERSION=$(xtrabackup --version 2>&1 | awk '/^xtrabackup version/{print $3}' | awk -F'.' '{print $1"."$2}')
 DATADIR=${DATADIR:-/var/lib/mysql}
 PARALLEL=$(grep -c processor /proc/cpuinfo)
 XBCLOUD_ARGS="--curl-retriable-errors=7 --parallel=${PARALLEL} ${XBCLOUD_EXTRA_ARGS}"


### PR DESCRIPTION
[![K8SPS-469](https://badgen.net/badge/JIRA/K8SPS-469/green)](https://jira.percona.com/browse/K8SPS-469) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**DESCRIPTION**
---
**Problem:**
Restores fail on clusters with specified `.spec.mysql.vaultSecretName`

**Cause:**
xtrabackup started outputting an additional line when the command `xtrabackup --version` is executed:
```
bash-5.1$ xtrabackup --version
2025-10-08T13:35:51.700206-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql
xtrabackup version 8.4.0-4 based on MySQL server 8.4.0 Linux (x86_64) (revision id: c584cb20)
```
The `run-restore.sh` script uses this command to determine the xtrabackup version.
Previously, it expected output such as 8.0 or 8.4, but now it receives an additional line, resulting in:
```
[Note].
8.4
```

**Solution:**
Extract the line containing the `xtrabackup version` prefix and parse the version from that line



**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-469]: https://perconadev.atlassian.net/browse/K8SPS-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ