### PR TITLE
K8SPS-578 add GCP storage example for backups in CR

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -656,6 +656,13 @@ spec:
 #          prefix: PREFIX-NAME
 #          endpointUrl: https://accountName.blob.core.windows.net
 #          credentialsSecret: SECRET-NAME
+#      gcp-cs:
+#        type: gcs
+#        gcs:
+#          bucket: BUCKET-NAME
+#          prefix: PREFIX-NAME
+#          endpointUrl: https://storage.googleapis.com
+#          credentialsSecret: SECRET-NAME
       s3-us-west:
         type: s3
         verifyTLS: true


### PR DESCRIPTION
[![K8SPS-578](https://badgen.net/badge/JIRA/K8SPS-578/green)](https://jira.percona.com/browse/K8SPS-578) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-578]: https://perconadev.atlassian.net/browse/K8SPS-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ