### PR TITLE
K8SPS-553 improve pvc-resize test

### DIFF
--- a/e2e-tests/tests/pvc-resize/02-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/02-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120
+timeout: 60
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/e2e-tests/tests/pvc-resize/02-write-data.yaml
+++ b/e2e-tests/tests/pvc-resize/02-write-data.yaml
@@ -1,7 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 180
+  - timeout: 60
     script: |-
       set -o errexit
       set -o xtrace
@@ -13,11 +13,7 @@ commands:
           "CREATE DATABASE IF NOT EXISTS pvctest; CREATE TABLE IF NOT EXISTS pvctest.data (id int PRIMARY KEY, data text)" \
           "-h $haproxy_svc"
 
-      for i in {1..50}; do
-          run_mysql \
-              "INSERT pvctest.data (id, data) VALUES ($i, 'test data row $i with some content to use storage space')" \
-              "-h $haproxy_svc"
-      done
+      run_mysql_query_file "conf/initial-data.sql" "-h $haproxy_svc"
 
       # Store initial data count for verification
       count=$(run_mysql "SELECT COUNT(*) FROM pvctest.data" "-h $haproxy_svc")

--- a/e2e-tests/tests/pvc-resize/conf/initial-data.sql
+++ b/e2e-tests/tests/pvc-resize/conf/initial-data.sql
@@ -1,0 +1,20 @@
+USE pvctest;
+DROP PROCEDURE IF EXISTS insert_pvc_test_data;
+
+DELIMITER //
+
+CREATE PROCEDURE insert_pvc_test_data()
+BEGIN
+  DECLARE i INT DEFAULT 1;
+  WHILE i <= 50 DO
+    INSERT INTO data (id, data)
+    VALUES (i, CONCAT('test data row ', i, ' with some content to use storage space'));
+    SET i = i + 1;
+  END WHILE;
+END;
+//
+
+DELIMITER ;
+
+CALL insert_pvc_test_data();
+DROP PROCEDURE insert_pvc_test_data;


### PR DESCRIPTION
[![K8SPS-553](https://badgen.net/badge/JIRA/K8SPS-553/green)](https://jira.percona.com/browse/K8SPS-553) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
For some specific cloud pvc-resize is failing cause writing data running kubectl command is taking time. To avoid increasing test time, this commit is including a query to add all necessary data for verification with a single kubectl execution.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPS-553]: https://perconadev.atlassian.net/browse/K8SPS-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ