### PR TITLE
K8SPS-215: remove PVCs for async restore

### DIFF
--- a/pkg/controller/psrestore/controller.go
+++ b/pkg/controller/psrestore/controller.go
@@ -242,7 +242,7 @@ func (r *PerconaServerMySQLRestoreReconciler) Reconcile(ctx context.Context, req
 	}
 
 	if status.State == apiv1.RestoreSucceeded {
-		if cluster.Spec.MySQL.IsGR() {
+		if cluster.CompareVersion("1.1.0") >= 0 || cluster.Spec.MySQL.IsGR() {
 			if err := r.deletePVCs(ctx, cluster); err != nil {
 				return ctrl.Result{}, errors.Wrap(err, "delete PVCs")
 			}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPS-215

**DESCRIPTION**
---
This PR removes PVCs for all non-zero pods after restoring on an `async` cluster, aligning the behaviour with the existing `group-replication` restore logic

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
