### PR TITLE
CLOUD-727 group together prs of the k8s.io pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,7 @@ updates:
       day: "wednesday"
       time: "01:00"
     groups:
-      k8s-io:
+      k8s-ecosystem:
         patterns:
           - "k8s.io/*"
+          - "sigs.k8s.io/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,7 @@ updates:
       interval: weekly
       day: "wednesday"
       time: "01:00"
+    groups:
+      k8s-io:
+        patterns:
+          - "k8s.io/*"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

 With the current setup, k8s.io (or sigs.k8s.io) dependencies are bumped individually, and sometimes one relies on another, creating problems with PR merge ordering and running tests, especially e2e tests, without reason. With this PR, we combine the updates into a single PR so that we can merge them all together.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
