### PR TITLE
K8SPS-739: use Router.Size instead of HAProxy.Size in passwordsPropagated

### DIFF
--- a/pkg/controller/ps/user.go
+++ b/pkg/controller/ps/user.go
@@ -401,7 +401,7 @@ func (r *PerconaServerMySQLReconciler) passwordsPropagated(ctx context.Context, 
 	if cr.RouterEnabled() {
 		components = append(components, component{
 			name:      router.AppName,
-			size:      int(cr.Spec.Proxy.HAProxy.Size),
+			size:      int(cr.Spec.Proxy.Router.Size),
 			credsPath: router.CredsMountPath,
 		})
 	}


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `passwordsPropagated` where the Router component incorrectly used `cr.Spec.Proxy.HAProxy.Size` instead of `cr.Spec.Proxy.Router.Size` when checking if updated passwords have been propagated to all component pods.

## Bug Details

In `pkg/controller/ps/user.go`, the `passwordsPropagated` function iterates over component pods (from index 0 to `size-1`) to verify that password files mounted in each pod match the new secret. The Router component was using HAProxy's size instead of its own.

## Impact

**Most affected: Router-only clusters (Group Replication)**
- HAProxy is disabled → `HAProxy.Size` defaults to 0
- The check loop runs 0 times for Router pods
- Old passwords are discarded from MySQL without verification
- Router pods still holding old credentials fail to connect → cluster becomes unreachable

**Mixed HAProxy + Router with different sizes:**
- If `HAProxy.Size < Router.Size`: only a subset of Router pods are verified, unchecked pods may lose connectivity after password rotation
- If `HAProxy.Size > Router.Size`: attempts to check non-existent pods, returns NotFound which is silently swallowed, verification is incomplete

## Fix

One-line change: `cr.Spec.Proxy.HAProxy.Size` → `cr.Spec.Proxy.Router.Size`

## Testing

- [x] `go build ./...` passes
- [x] `go vet ./pkg/controller/ps/...` passes
- [x] Unit tests pass (envtest integration tests require etcd binary, unrelated to this change)