### PR TITLE
K8SPS-638 do not load Group Replication plugin for async clusters

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -460,7 +460,9 @@ if [ "$1" = 'mysqld' ] && [ -z "$wantHelp" ]; then
 		echo
 	fi
 
-	load_group_replication_plugin
+	if [[ ${CLUSTER_TYPE} != "async" ]]; then
+		load_group_replication_plugin
+	fi
 	ensure_read_only
 
 	# exit when MYSQL_INIT_ONLY environment variable is set to avoid starting mysqld

--- a/e2e-tests/tests/config/12-assert.yaml
+++ b/e2e-tests/tests/config/12-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 12-check-no-gr-plugin-0
+data:
+  group_replication_plugins: "0"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 12-check-no-gr-plugin-1
+data:
+  group_replication_plugins: "0"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 12-check-no-gr-plugin-2
+data:
+  group_replication_plugins: "0"

--- a/e2e-tests/tests/config/12-check-no-gr-plugin.yaml
+++ b/e2e-tests/tests/config/12-check-no-gr-plugin.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 120
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      # The Group Replication plugin must not be loaded on async clusters.
+      idx=0
+      for pod in $(kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/component=database' -o jsonpath='{.items[*].metadata.name}'); do
+          gr_plugins=$(kubectl -n "${NAMESPACE}" exec "${pod}" -c mysql -- bash -c \
+              'mysql -uroot -p"$(cat /etc/mysql/mysql-users-secret/root)" -NB -e "SELECT COUNT(*) FROM information_schema.plugins WHERE PLUGIN_NAME = \"group_replication\""')
+          echo "${pod}: group_replication plugins loaded: ${gr_plugins}"
+          kubectl -n "${NAMESPACE}" create configmap "12-check-no-gr-plugin-${idx}" \
+              --from-literal=group_replication_plugins="${gr_plugins}"
+          idx=$((idx + 1))
+      done


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

**Solution:**
*Load the plugin only when the cluster type is not async, using the
CLUSTER_TYPE environment variable the operator already sets on the mysql
container.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
