### PR TITLE
K8SPS-682 disable NUMA interleave by default for MySQL 8.4

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -212,6 +212,10 @@ create_default_cnf() {
 		sed -i "/\[mysqld\]/a innodb_parallel_dblwr_encrypt=ON" $CFG
 	fi
 
+	if [ "$MYSQL_VERSION" == '8.4' ]; then
+		sed -i '/\[mysqld\]/a innodb_numa_interleave=OFF' $CFG
+	fi
+
 	for f in "${CUSTOM_CONFIG_FILES[@]}"; do
 		echo "${f}"
 		if [ -f "${f}" ]; then

--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -213,7 +213,7 @@ create_default_cnf() {
 	fi
 
 	if [ "$MYSQL_VERSION" == '8.4' ]; then
-		sed -i '/\[mysqld\]/a innodb_numa_interleave=OFF' $CFG
+		sed -i "/\[mysqld\]/a innodb_numa_interleave=OFF" $CFG
 	fi
 
 	for f in "${CUSTOM_CONFIG_FILES[@]}"; do

--- a/e2e-tests/tests/gr-init-deploy/11-check-numa.yaml
+++ b/e2e-tests/tests/gr-init-deploy/11-check-numa.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      if [ "${MYSQL_VERSION}" != "8.4" ]; then
+          echo "skip: innodb_numa_interleave is only disabled by default for 8.4"
+          exit 0
+      fi
+
+      numa=$(run_mysql \
+          "SELECT @@innodb_numa_interleave" \
+          "-h $(get_mysql_router_service $(get_cluster_name)) -P 6446")
+      if [ "${numa}" != "0" ]; then
+          echo "expected innodb_numa_interleave=OFF (0), got: '${numa}'"
+          exit 1
+      fi

--- a/e2e-tests/tests/init-deploy/08-check-numa.yaml
+++ b/e2e-tests/tests/init-deploy/08-check-numa.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      if [ "${MYSQL_VERSION}" != "8.4" ]; then
+          echo "skip: innodb_numa_interleave is only disabled by default for 8.4"
+          exit 0
+      fi
+
+      numa=$(run_mysql \
+          "SELECT @@innodb_numa_interleave" \
+          "-h $(get_haproxy_svc $(get_cluster_name))" "-uroot -proot_password")
+      if [ "${numa}" != "0" ]; then
+          echo "expected innodb_numa_interleave=OFF (0), got: '${numa}'"
+          exit 1
+      fi


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

**Solution:**
Set innodb_numa_interleave=OFF in the default node.cnf for 8.4 (matching the PXC operator). Placed before custom config files so users can still override it. Add e2e checks asserting @@innodb_numa_interleave=0 for async (init-deploy) and GR (gr-init-deploy), gated to 8.4.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
