### PR TITLE
K8SPS-781: Add custom names for orchestrator RBAC resources

### DIFF
--- a/api/v1/perconaservermysql_types.go
+++ b/api/v1/perconaservermysql_types.go
@@ -1071,6 +1071,14 @@ func (cr *PerconaServerMySQL) DefaultSSLSecretName() string {
 	return cr.Name + "-ssl"
 }
 
+func (cr *PerconaServerMySQL) DefaultOrchestratorServiceAccountName() string {
+	if cr.Spec.CRVersion != "" && cr.CompareVersion("1.3.0") >= 0 {
+		return cr.Name + "-orchestrator"
+	}
+
+	return "percona-server-mysql-operator-orchestrator"
+}
+
 // CheckNSetDefaults validates and sets default values for the PerconaServerMySQL custom resource.
 func (cr *PerconaServerMySQL) CheckNSetDefaults(_ context.Context, serverVersion *platform.ServerVersion) error {
 	if len(cr.Spec.MySQL.ClusterType) == 0 {
@@ -1272,7 +1280,7 @@ func (cr *PerconaServerMySQL) CheckNSetDefaults(_ context.Context, serverVersion
 	}
 
 	if cr.Spec.Orchestrator.ServiceAccountName == "" {
-		cr.Spec.Orchestrator.ServiceAccountName = "percona-server-mysql-operator-orchestrator"
+		cr.Spec.Orchestrator.ServiceAccountName = cr.DefaultOrchestratorServiceAccountName()
 	}
 
 	var err error

--- a/api/v1/perconaservermysql_types_test.go
+++ b/api/v1/perconaservermysql_types_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/percona/percona-server-mysql-operator/pkg/naming"
 )
@@ -848,4 +849,32 @@ func TestPiTREnabled(t *testing.T) {
 			assert.Equal(t, tc.want, cr.PiTREnabled())
 		})
 	}
+}
+
+func TestDefaultOrchestratorServiceAccountName(t *testing.T) {
+	t.Run("empty crVersion", func(t *testing.T) {
+		cr := &PerconaServerMySQL{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a"},
+		}
+
+		assert.Equal(t, "percona-server-mysql-operator-orchestrator", cr.DefaultOrchestratorServiceAccountName())
+	})
+
+	t.Run("before 1.3.0", func(t *testing.T) {
+		cr := &PerconaServerMySQL{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a"},
+			Spec:       PerconaServerMySQLSpec{CRVersion: "1.2.0"},
+		}
+
+		assert.Equal(t, "percona-server-mysql-operator-orchestrator", cr.DefaultOrchestratorServiceAccountName())
+	})
+
+	t.Run("since 1.3.0", func(t *testing.T) {
+		cr := &PerconaServerMySQL{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a"},
+			Spec:       PerconaServerMySQLSpec{CRVersion: "1.3.0"},
+		}
+
+		assert.Equal(t, "cluster-a-orchestrator", cr.DefaultOrchestratorServiceAccountName())
+	})
 }

--- a/cmd/example-gen/pkg/defaults/manual.go
+++ b/cmd/example-gen/pkg/defaults/manual.go
@@ -24,7 +24,7 @@ func ManualCluster(cr *apiv1.PerconaServerMySQL) {
 	mysqlDefaults(&cr.Spec.MySQL)
 	haproxyDefaults(cr.Spec.Proxy.HAProxy)
 	routerDefaults(cr.Spec.Proxy.Router)
-	orchestratorDefaults(&cr.Spec.Orchestrator)
+	orchestratorDefaults(cr, &cr.Spec.Orchestrator)
 	pmmDefaults(cr.Spec.PMM)
 	toolkitDefaults(cr.Spec.Toolkit)
 	backupDefaults(cr.Spec.Backup)
@@ -107,12 +107,12 @@ func routerDefaults(spec *apiv1.MySQLRouterSpec) {
 	}
 }
 
-func orchestratorDefaults(spec *apiv1.OrchestratorSpec) {
+func orchestratorDefaults(cr *apiv1.PerconaServerMySQL, spec *apiv1.OrchestratorSpec) {
 	podSpecDefaults(&spec.PodSpec, ImageOrchestrator, resources("128M", "", "256M", ""), "", 30, envList("ORC_ENV", "VALUE"), envFromList("orc-env-secret"))
 
 	spec.Enabled = false
 	spec.Configuration = `{"FailMasterPromotionOnLagMinutes": 10}`
-	spec.ServiceAccountName = "percona-server-mysql-operator-orchestrator"
+	spec.ServiceAccountName = cr.DefaultOrchestratorServiceAccountName()
 	spec.PodSecurityContext = &corev1.PodSecurityContext{
 		SupplementalGroups: []int64{1001},
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -605,7 +605,7 @@ func ConfigMapData(cr *apiv1.PerconaServerMySQL) (string, error) {
 func RBAC(cr *apiv1.PerconaServerMySQL) (*rbacv1.Role, *rbacv1.RoleBinding, *corev1.ServiceAccount) {
 	meta := metav1.ObjectMeta{
 		Namespace:   cr.Namespace,
-		Name:        "percona-server-mysql-operator-orchestrator",
+		Name:        cr.Spec.Orchestrator.ServiceAccountName,
 		Labels:      cr.GlobalLabels(),
 		Annotations: cr.GlobalAnnotations(),
 	}

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -136,6 +136,53 @@ func TestStatefulSet(t *testing.T) {
 		assert.Equal(t, serviceAccountName, sts.Spec.Template.Spec.ServiceAccountName)
 	})
 
+	t.Run("RBAC", func(t *testing.T) {
+		cluster := cr.DeepCopy()
+		cluster.Spec.CRVersion = "1.2.0"
+		cluster.Spec.Orchestrator.ServiceAccountName = ""
+
+		if err := cluster.CheckNSetDefaults(t.Context(), &platform.ServerVersion{
+			Platform: platform.PlatformKubernetes,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		role, binding, sa := RBAC(cluster)
+		const legacyDefaultName = "percona-server-mysql-operator-orchestrator"
+		assert.Equal(t, legacyDefaultName, sa.Name)
+		assert.Equal(t, legacyDefaultName, role.Name)
+		assert.Equal(t, legacyDefaultName, binding.Name)
+		assert.Equal(t, legacyDefaultName, binding.Subjects[0].Name)
+		assert.Equal(t, legacyDefaultName, binding.RoleRef.Name)
+
+		cluster.Spec.CRVersion = "1.3.0"
+		cluster.Spec.Orchestrator.ServiceAccountName = ""
+
+		if err := cluster.CheckNSetDefaults(t.Context(), &platform.ServerVersion{
+			Platform: platform.PlatformKubernetes,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		role, binding, sa = RBAC(cluster)
+		const modernDefaultName = "cluster-orchestrator"
+		assert.Equal(t, modernDefaultName, sa.Name)
+		assert.Equal(t, modernDefaultName, role.Name)
+		assert.Equal(t, modernDefaultName, binding.Name)
+		assert.Equal(t, modernDefaultName, binding.Subjects[0].Name)
+		assert.Equal(t, modernDefaultName, binding.RoleRef.Name)
+
+		const customName = "custom-orchestrator"
+		cluster.Spec.Orchestrator.ServiceAccountName = customName
+
+		role, binding, sa = RBAC(cluster)
+		assert.Equal(t, customName, sa.Name)
+		assert.Equal(t, customName, role.Name)
+		assert.Equal(t, customName, binding.Name)
+		assert.Equal(t, customName, binding.Subjects[0].Name)
+		assert.Equal(t, customName, binding.RoleRef.Name)
+	})
+
 	t.Run("tolerations", func(t *testing.T) {
 		cluster := cr.DeepCopy()
 		sts := StatefulSet(cluster, initImage, configHash, tlsHash)


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
When multiple PerconaServerMySQL clusters with Orchestrator enabled are deployed in the same namespace, they conflict over a single set of RBAC resources (ServiceAccount, Role, RoleBinding) named percona-server-mysql-operator-orchestrator. This can cause reconcile errors (controller owner reference conflicts) and prevents running multiple Orchestrator instances in one namespace.

**Cause:**
spec.orchestrator.serviceAccountName was already supported for Orchestrator pods, but orchestrator.RBAC() always created RBAC objects with a hardcoded name (percona-server-mysql-operator-orchestrator), ignoring the CR value. As a result, all clusters in a namespace shared the same RBAC objects regardless of the configured service account name.
**Solution:**
Use cr.Spec.Orchestrator.ServiceAccountName (after defaults are applied) as the name for all Orchestrator RBAC resources: ServiceAccount, Role, and RoleBinding. Each cluster can now get an isolated RBAC set by setting a unique spec.orchestrator.serviceAccountName. If the field is not set, the default percona-server-mysql-operator-orchestrator is preserved — existing single-cluster deployments are unaffected.

**CHECKLIST**
---
**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
    No E2E test — behavior fix for an existing field; covered by unit tests. Can add a multi-orchestrator E2E if the team wants it.
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files? 
    no new option — spec.orchestrator.serviceAccountName already exists and is documented in deploy/cr.yaml
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
    no Helm changes required — field already exposed
- [x] Did we add proper logging messages for operator actions?
    not applicable — behavior fix, no new operator actions
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?

    Backward compatible via `crVersion` gate:
    - `crVersion < 1.3.0` (or empty): legacy default SA name `percona-server-mysql-operator-orchestrator` is preserved
    - `crVersion >= 1.3.0`: new per-cluster default `{cr.Name}-orchestrator`
    - explicit `spec.orchestrator.serviceAccountName` always overrides defaults
    
    Upgrade path:
    - After bumping `spec.crVersion` to `1.3.0`, the operator creates new per-cluster RBAC resources
    - Legacy shared SA/Role/RoleBinding can be removed manually if no longer used

- [x] Does the change support oldest and newest supported PS version?
- [x] Does the change support oldest and newest supported Kubernetes version?
