### PR TITLE
K8SPS-508: clusterset status improvements

### DIFF
--- a/api/v1/perconaservermysqlclusterset_types.go
+++ b/api/v1/perconaservermysqlclusterset_types.go
@@ -18,10 +18,12 @@ package v1
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	k8sretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -291,7 +293,13 @@ func (psc *PerconaServerMySQLClusterSet) GetCluster(name string) *ClusterSetClus
 }
 
 func (pcs *PerconaServerMySQLClusterSet) UpdateStatus(ctx context.Context, cl client.Client, mutate func(status *PerconaServerMySQLClusterSetStatus) error) error {
-	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 1 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
+	return k8sretry.RetryOnConflict(backoff, func() error {
 		actual := &PerconaServerMySQLClusterSet{}
 		if err := cl.Get(ctx, types.NamespacedName{Name: pcs.Name, Namespace: pcs.Namespace}, actual); err != nil {
 			return err

--- a/api/v1/perconaservermysqlclusterset_types.go
+++ b/api/v1/perconaservermysqlclusterset_types.go
@@ -233,9 +233,9 @@ const (
 	ConditionClusterSetBootstrapped            string = "ClusterSetBootstrapped"
 	ConditionClusterSetPrimarySwitchOverInProg string = "SwitchoverInProgress"
 	ConditionReplicaManagementFailure          string = "ReplicaManagementFailure"
-	ConditionPrimaryClusterUnreachable         string = "PrimaryClusterUnreachable"
 	ConditionClusterSetDissolving              string = "ClusterSetDissolving"
 	ConditionClusterSetReady                   string = "Ready"
+	ConditionClusterSetErrorReconcile          string = "ErrorReconcile"
 )
 
 type ClusterSetStatus map[string]ClusterSetClusterStatus

--- a/e2e-tests/tests/gr-cross-cluster-backup/01-assert.yaml
+++ b/e2e-tests/tests/gr-cross-cluster-backup/01-assert.yaml
@@ -60,14 +60,14 @@ spec:
       mode: manual
 status:
   conditions:
+  - message: Awaiting external bootstrap
+    reason: ManualBootstrapRequested
+    status: "True"
+    type: AwaitingExternalBootstrap
   - reason: Initializing
     status: "True"
     type: Initializing
   - reason: Ready
     status: "False"
     type: Ready
-  - message: Awaiting external bootstrap
-    reason: ManualBootstrapRequested
-    status: "True"
-    type: AwaitingExternalBootstrap
   state: initializing

--- a/e2e-tests/tests/gr-cross-cluster-backup/05-assert.yaml
+++ b/e2e-tests/tests/gr-cross-cluster-backup/05-assert.yaml
@@ -15,6 +15,10 @@ metadata:
   name: gr-cross-cluster-backup-dc2
 status:
   conditions:
+  - message: Awaiting external bootstrap
+    reason: ManualBootstrapRequested
+    status: "True"
+    type: AwaitingExternalBootstrap
   - reason: Initializing
     status: "True"
     type: Initializing
@@ -25,10 +29,6 @@ status:
     reason: InnoDBClusterBootstrapped
     status: "False"
     type: InnoDBClusterBootstrapped
-  - message: Awaiting external bootstrap
-    reason: ManualBootstrapRequested
-    status: "True"
-    type: AwaitingExternalBootstrap
   mysql:
     state: initializing
   state: initializing

--- a/e2e-tests/tests/gr-cross-cluster/01-assert.yaml
+++ b/e2e-tests/tests/gr-cross-cluster/01-assert.yaml
@@ -60,14 +60,14 @@ spec:
       mode: manual
 status:
   conditions:
+  - message: Awaiting external bootstrap
+    reason: ManualBootstrapRequested
+    status: "True"
+    type: AwaitingExternalBootstrap
   - reason: Initializing
     status: "True"
     type: Initializing
   - reason: Ready
     status: "False"
     type: Ready
-  - message: Awaiting external bootstrap
-    reason: ManualBootstrapRequested
-    status: "True"
-    type: AwaitingExternalBootstrap
   state: initializing

--- a/e2e-tests/tests/gr-cross-cluster/25-assert.yaml
+++ b/e2e-tests/tests/gr-cross-cluster/25-assert.yaml
@@ -22,14 +22,14 @@ spec:
       mode: manual
 status:
   conditions:
+  - message: Awaiting external bootstrap
+    reason: ManualBootstrapRequested
+    status: "True"
+    type: AwaitingExternalBootstrap
   - reason: Initializing
     status: "True"
     type: Initializing
   - reason: Ready
     status: "False"
     type: Ready
-  - message: Awaiting external bootstrap
-    reason: ManualBootstrapRequested
-    status: "True"
-    type: AwaitingExternalBootstrap
   state: initializing

--- a/pkg/clusterset/manager/errors.go
+++ b/pkg/clusterset/manager/errors.go
@@ -1,0 +1,75 @@
+package manager
+
+import "errors"
+
+// ClusterSetManagerError implements the error interface
+var _ error = &ClusterSetManagerError{}
+
+type ClusterSetManagerError struct {
+	reason  string
+	message string
+}
+
+func (e *ClusterSetManagerError) Error() string {
+	return e.reason + ": " + e.message
+}
+
+func (e *ClusterSetManagerError) Reason() string {
+	return e.reason
+}
+
+func (e *ClusterSetManagerError) Message() string {
+	return e.message
+}
+
+const (
+	reasonPrimaryUnreachable = "PrimaryUnreachable"
+	reasonAccessDenied       = "AccessDenied"
+	reasonGenericError       = "ClusterSetManagerError"
+)
+
+func newClusterSetManagerError(reason, message string) *ClusterSetManagerError {
+	return &ClusterSetManagerError{
+		reason:  reason,
+		message: message,
+	}
+}
+
+// NewUnreachableError returns an error indicating that no endpoint of the
+// primary cluster could be reached.
+func NewUnreachableError() *ClusterSetManagerError {
+	return newClusterSetManagerError(
+		reasonPrimaryUnreachable,
+		"No reachable endpoint for the primary cluster",
+	)
+}
+
+// NewAccessDeniedError returns an error indicating that the clusterset
+// credentials were rejected by the primary cluster.
+func NewAccessDeniedError() *ClusterSetManagerError {
+	return newClusterSetManagerError(
+		reasonAccessDenied,
+		"Invalid credentials for the primary cluster",
+	)
+}
+
+// NewGenericError returns an error for any other cluster set manager failure.
+func NewGenericError(message string) *ClusterSetManagerError {
+	return newClusterSetManagerError(
+		reasonGenericError,
+		message,
+	)
+}
+
+func AsManagerError(err error) *ClusterSetManagerError {
+	target := &ClusterSetManagerError{}
+	if errors.As(err, &target) {
+		return target
+	}
+	return nil
+}
+
+func IsUnreachableError(err error) bool {
+	target := AsManagerError(err)
+	return target != nil && target.Reason() == reasonPrimaryUnreachable
+}

--- a/pkg/clusterset/manager/manager.go
+++ b/pkg/clusterset/manager/manager.go
@@ -61,14 +61,14 @@ func New(ctx context.Context, pcs *apiv1.PerconaServerMySQLClusterSet, opts *Man
 			if errors.Is(err, mysqlsh.ErrEndpointUnreachable) {
 				continue
 			}
-			return nil, errors.Wrap(err, "ping")
+			if errors.Is(err, mysqlsh.ErrAccessDenied) {
+				return nil, NewAccessDeniedError()
+			}
+			return nil, NewGenericError(err.Error())
 		}
-
 		return &mysqlshellClusterSetManager{shell: shell}, nil
 	}
-
-	return nil, errors.Wrap(mysqlsh.ErrEndpointUnreachable, "all endpoints are unreachable")
-
+	return nil, NewUnreachableError()
 }
 
 func getClusterSetPassword(ctx context.Context, cl client.Client, pcs *apiv1.PerconaServerMySQLClusterSet) (string, error) {

--- a/pkg/clusterset/status.go
+++ b/pkg/clusterset/status.go
@@ -4,6 +4,7 @@ import apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
 
 const (
 	StatusHealthy string = "HEALTHY"
+	StatusUnknown string = "UNKNOWN"
 )
 
 const (

--- a/pkg/controller/ps/status.go
+++ b/pkg/controller/ps/status.go
@@ -213,7 +213,6 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 				r.Recorder.Event(cr, corev1.EventTypeWarning, "FullClusterCrashDetected", "Full cluster crash detected")
 			}
 
-			meta.RemoveStatusCondition(&status.Conditions, apiv1.ConditionAwaitingExternalBootstrap)
 			if ok, err := r.isAwaitingExtBootstrap(ctx, cr); err != nil {
 				return errors.Wrap(err, "check if awaiting external bootstrap")
 			} else if ok {
@@ -223,6 +222,8 @@ func (r *PerconaServerMySQLReconciler) reconcileCRStatus(ctx context.Context, cr
 					Reason:  "ManualBootstrapRequested",
 					Message: "Awaiting external bootstrap",
 				})
+			} else {
+				meta.RemoveStatusCondition(&status.Conditions, apiv1.ConditionAwaitingExternalBootstrap)
 			}
 		}
 

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -178,30 +178,27 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 			return nil
 		}
 
-		cond := metav1.Condition{
+		accessDenied := errors.Is(rErr, mysqlsh.ErrAccessDenied)
+		unreachable := errors.Is(rErr, mysqlsh.ErrEndpointUnreachable)
+		lostPrimaryConnection := accessDenied || unreachable || errors.Is(rErr, errGetClusterSetManager)
+
+		errCond := metav1.Condition{
 			Type:    apiv1.ConditionClusterSetErrorReconcile,
 			Status:  metav1.ConditionTrue,
 			Message: rErr.Error(),
 			Reason:  "ReconcileError",
 		}
-
-		// handle known failures
 		switch {
-		case errors.Is(rErr, mysqlsh.ErrAccessDenied):
-			cond.Reason = "AccessDenied"
-			cond.Message = "Access denied on primary, check the clusterset credentials"
-			markAllNodesUnknown(status)
-		case errors.Is(rErr, mysqlsh.ErrEndpointUnreachable):
-			cond.Reason = "PrimaryClusterUnreachable"
-			cond.Message = "Primary cluster is unreachable, check the network and cluster status"
-			markAllNodesUnknown(status)
+		case accessDenied:
+			errCond.Reason = "AccessDenied"
+			errCond.Message = "Access denied on primary, check the clusterset credentials"
+		case unreachable:
+			errCond.Reason = "PrimaryClusterUnreachable"
+			errCond.Message = "Primary cluster is unreachable, check the network and cluster status"
 		}
+		meta.SetStatusCondition(&status.Conditions, errCond)
 
-		meta.SetStatusCondition(&status.Conditions, cond)
-
-		// without connecting to the primary cluster, we no longer know for sure if
-		// everything is up and running correctly.
-		if errors.Is(rErr, errGetClusterSetManager) {
+		if lostPrimaryConnection {
 			markAllNodesUnknown(status)
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionClusterSetReady,
@@ -211,7 +208,6 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 			})
 		}
 		return nil
-
 	}); updErr != nil {
 		return errors.Wrap(updErr, "update status")
 	}

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -111,17 +111,15 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 	}
 
 	manager, err := r.getClusterSetManager(ctx, pcs)
-	if updErr := r.reconcilePrimaryClusterUnreachableCondition(ctx, pcs, err); updErr != nil {
-		return ctrl.Result{}, errors.Wrap(updErr, "reconcile primary cluster unreachable condition")
+	if updErr := r.handleClusterSetManagerError(ctx, pcs, err); updErr != nil {
+		return ctrl.Result{}, errors.Wrap(updErr, "handle cluster set manager error")
 	}
 
 	if errors.Is(err, mysqlsh.ErrEndpointUnreachable) {
-		if xerr := r.reconcileForcedFailover(ctx, pcs); xerr != nil {
-			return ctrl.Result{}, errors.Wrap(xerr, "reconcile forced failover")
+		if err := r.reconcileForcedFailover(ctx, pcs); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "reconcile forced failover")
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-	} else if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "get cluster set manager")
 	}
 
 	if err := r.bootstrapClusterSet(ctx, pcs, manager); err != nil {
@@ -147,13 +145,54 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (r *PerconaServerMySQLClusterSetReconciler) reconcilePrimaryClusterUnreachableCondition(
+func (r *PerconaServerMySQLClusterSetReconciler) handleClusterSetManagerError(
+	ctx context.Context,
+	pcs *apiv1.PerconaServerMySQLClusterSet,
+	csErr error,
+) error {
+	if err := r.reconcileErrorCondAccessDenied(ctx, pcs, csErr); err != nil {
+		return errors.Wrap(err, "reconcile access denied condition")
+	}
+	if err := r.reconcileErrorCondPrimaryUnreachable(ctx, pcs, csErr); err != nil {
+		return errors.Wrap(err, "reconcile primary cluster unreachable condition")
+	}
+	return nil
+}
+
+func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondAccessDenied(
+	ctx context.Context,
+	pcs *apiv1.PerconaServerMySQLClusterSet,
+	csErr error,
+) error {
+	if errors.Is(csErr, mysqlsh.ErrAccessDenied) {
+		return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
+			for name, c := range status.Clusters {
+				c.GlobalStatus = clusterset.StatusUnknown
+				status.Clusters[name] = c
+			}
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:    apiv1.ConditionClusterSetReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  "AccessDenied",
+				Message: "Invalid credentials for clusterset user",
+			})
+			return nil
+		})
+	}
+	return nil
+}
+
+func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondPrimaryUnreachable(
 	ctx context.Context,
 	pcs *apiv1.PerconaServerMySQLClusterSet,
 	csErr error,
 ) error {
 	if errors.Is(csErr, mysqlsh.ErrEndpointUnreachable) {
 		return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
+			for name, c := range status.Clusters {
+				c.GlobalStatus = clusterset.StatusUnknown
+				status.Clusters[name] = c
+			}
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionPrimaryClusterUnreachable,
 				Status:  metav1.ConditionTrue,
@@ -171,6 +210,33 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcilePrimaryClusterUnreacha
 
 	return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
 		meta.RemoveStatusCondition(&status.Conditions, apiv1.ConditionPrimaryClusterUnreachable)
+		return nil
+	})
+}
+
+// mysqlErrAccessDenied is MySQL error code 1045 (ER_ACCESS_DENIED_ERROR),
+// reported when the clusterset user authenticates with invalid credentials.
+const mysqlErrAccessDenied = "1045"
+
+// reconcileInvalidCredentialsCondition sets ClusterSetReady=False when the
+// ClusterSet manager error indicates the clusterset user's credentials were
+// rejected. Other errors leave the conditions untouched.
+func (r *PerconaServerMySQLClusterSetReconciler) reconcileInvalidCredentialsCondition(
+	ctx context.Context,
+	pcs *apiv1.PerconaServerMySQLClusterSet,
+	csErr error,
+) error {
+	if !strings.Contains(csErr.Error(), mysqlErrAccessDenied) {
+		return nil
+	}
+
+	return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:    apiv1.ConditionClusterSetReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  "AccessDenied",
+			Message: "Invalid credentials for clusterset user",
+		})
 		return nil
 	})
 }

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -3,6 +3,7 @@ package psclusterset
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,19 +17,21 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
 	"github.com/percona/percona-server-mysql-operator/pkg/clientcmd"
 	"github.com/percona/percona-server-mysql-operator/pkg/clusterset"
 	csmanager "github.com/percona/percona-server-mysql-operator/pkg/clusterset/manager"
 	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
-	"github.com/percona/percona-server-mysql-operator/pkg/mysqlsh"
 	"github.com/percona/percona-server-mysql-operator/pkg/naming"
 	k8sutil "github.com/percona/percona-server-mysql-operator/pkg/util/k8s"
 )
@@ -71,12 +74,64 @@ func (r *PerconaServerMySQLClusterSetReconciler) SetupWithManager(mgr ctrl.Manag
 	}
 	r.jobImage = operatorPod.Spec.Containers[0].Image
 
+	if err := setupFieldIndexers(mgr); err != nil {
+		return errors.Wrap(err, "setup field indexers")
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.PerconaServerMySQLClusterSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
+		Watches(&corev1.Secret{}, enqueueFromCredentialsSecret(r.Client)).
 		Named(controllerName).
 		Complete(r)
+}
+
+func enqueueFromCredentialsSecret(c client.Client) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		secret, ok := o.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
+		list := &apiv1.PerconaServerMySQLList{}
+		log := logf.FromContext(ctx)
+		if err := c.List(ctx, list, client.InNamespace(secret.Namespace), client.MatchingFields{
+			fieldSecretsName: secret.Name,
+		}); err != nil {
+			log.Error(err, "failed to list clusters for secret", "secret", secret.Name)
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, cluster := range list.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+			})
+		}
+		return requests
+	})
+}
+
+const fieldSecretsName = "spec.credentialsSecret.name"
+
+func setupFieldIndexers(mgr ctrl.Manager) error {
+	// Index secrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.PerconaServerMySQLClusterSet{}, fieldSecretsName, func(o client.Object) []string {
+		pcs, ok := o.(*apiv1.PerconaServerMySQLClusterSet)
+		if !ok {
+			return nil
+		}
+		if pcs.Spec.CredentialsSecret.Name != "" {
+			return []string{pcs.Spec.CredentialsSecret.Name}
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "index field %s", fieldSecretsName)
+	}
+	return nil
 }
 
 var errGetClusterSetManager = errors.New("get cluster set manager")
@@ -84,15 +139,12 @@ var errGetClusterSetManager = errors.New("get cluster set manager")
 //+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqlclustersets;perconaservermysqlclustersets/status;perconaservermysqlclustersets/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the PerconaServerMySQLClusterSet custom resource.
-func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, retErr error) {
+func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := logf.FromContext(ctx).WithName("PerconaServerMySQLClusterSet")
 
 	pcs := &apiv1.PerconaServerMySQLClusterSet{}
 	if err := r.Get(ctx, req.NamespacedName, pcs); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, errors.Wrap(err, "get PerconaServerMySQLClusterSet")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	pcs.SetDefaults()
@@ -101,10 +153,19 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, r.reconcileFinalizers(ctx, pcs)
 	}
 
-	var err error
 	defer func() {
-		if updErr := r.reconcileErrorCondition(ctx, pcs, err); updErr != nil && retErr == nil {
-			retErr = errors.Wrap(updErr, "reconcile error condition")
+		if updErr := r.reconcileErrorCondition(ctx, pcs, err); updErr != nil {
+			err = stderrors.Join(err, errors.Wrap(updErr, "reconcile error condition"))
+			return
+		}
+
+		// We want the controller to take over operations as soon as it can reach the cluster.
+		// Without the swallow and requeue, the controller would be subject to an exponential backoff,
+		// which can delay critical operations.
+		if csmanager.IsUnreachableError(err) {
+			log.Info("Primary cluster is unreachable, will retry in 10 seconds ...")
+			err = nil
+			result = ctrl.Result{RequeueAfter: 10 * time.Second}
 		}
 	}()
 
@@ -126,12 +187,12 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 
 	var manager ClusterSetManager
 	manager, err = r.getClusterSetManager(ctx, pcs)
-	if errors.Is(err, mysqlsh.ErrEndpointUnreachable) {
+	if csmanager.IsUnreachableError(err) {
 		if ffErr := r.reconcileForcedFailover(ctx, pcs); ffErr != nil {
 			err = errors.Wrap(ffErr, "reconcile forced failover")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{}, err
 	} else if err != nil {
 		err = fmt.Errorf("%w: %w", errGetClusterSetManager, err)
 		return ctrl.Result{}, err
@@ -178,35 +239,26 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 			return nil
 		}
 
-		accessDenied := errors.Is(rErr, mysqlsh.ErrAccessDenied)
-		unreachable := errors.Is(rErr, mysqlsh.ErrEndpointUnreachable)
-		lostPrimaryConnection := accessDenied || unreachable || errors.Is(rErr, errGetClusterSetManager)
-
 		errCond := metav1.Condition{
 			Type:    apiv1.ConditionClusterSetErrorReconcile,
 			Status:  metav1.ConditionTrue,
-			Message: rErr.Error(),
 			Reason:  "ReconcileError",
+			Message: fmt.Sprintf("Error during reconcile: %s", rErr.Error()),
 		}
-		switch {
-		case accessDenied:
-			errCond.Reason = "AccessDenied"
-			errCond.Message = "Access denied on primary, check the clusterset credentials"
-		case unreachable:
-			errCond.Reason = "PrimaryClusterUnreachable"
-			errCond.Message = "Primary cluster is unreachable, check the network and cluster status"
-		}
-		meta.SetStatusCondition(&status.Conditions, errCond)
 
-		if lostPrimaryConnection {
-			markAllNodesUnknown(status)
+		if csErr := csmanager.AsManagerError(rErr); csErr != nil {
+			errCond.Reason = csErr.Reason()
+			errCond.Message = csErr.Message()
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionClusterSetReady,
 				Status:  metav1.ConditionUnknown,
-				Message: fmt.Sprintf("Error connecting to primary cluster: %s", rErr.Error()),
-				Reason:  "ClusterSetManagerError",
+				Reason:  csErr.Reason(),
+				Message: csErr.Message(),
 			})
+			markAllNodesUnknown(status)
 		}
+
+		meta.SetStatusCondition(&status.Conditions, errCond)
 		return nil
 	}); updErr != nil {
 		return errors.Wrap(updErr, "update status")

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -84,7 +84,7 @@ var errGetClusterSetManager = errors.New("get cluster set manager")
 //+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqlclustersets;perconaservermysqlclustersets/status;perconaservermysqlclustersets/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the PerconaServerMySQLClusterSet custom resource.
-func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, retErr error) {
 	log := logf.FromContext(ctx).WithName("PerconaServerMySQLClusterSet")
 
 	pcs := &apiv1.PerconaServerMySQLClusterSet{}
@@ -103,8 +103,8 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 
 	var err error
 	defer func() {
-		if updErr := r.reconcileErrorCondition(ctx, pcs, err); updErr != nil {
-			err = errors.Wrap(updErr, "reconcile error condition")
+		if updErr := r.reconcileErrorCondition(ctx, pcs, err); updErr != nil && retErr == nil {
+			retErr = errors.Wrap(updErr, "reconcile error condition")
 		}
 	}()
 
@@ -127,8 +127,9 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 	var manager ClusterSetManager
 	manager, err = r.getClusterSetManager(ctx, pcs)
 	if errors.Is(err, mysqlsh.ErrEndpointUnreachable) {
-		if err := r.reconcileForcedFailover(ctx, pcs); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "reconcile forced failover")
+		if ffErr := r.reconcileForcedFailover(ctx, pcs); ffErr != nil {
+			err = errors.Wrap(ffErr, "reconcile forced failover")
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	} else if err != nil {
@@ -160,6 +161,10 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 	pcs *apiv1.PerconaServerMySQLClusterSet,
 	rErr error,
 ) error {
+	if rErr == nil && meta.FindStatusCondition(pcs.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile) == nil {
+		return nil
+	}
+
 	markAllNodesUnknown := func(status *apiv1.PerconaServerMySQLClusterSetStatus) {
 		for name, c := range status.Clusters {
 			c.GlobalStatus = clusterset.StatusUnknown

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -243,8 +243,8 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 
 		errCond := metav1.Condition{
 			Type:    apiv1.ConditionClusterSetErrorReconcile,
+			Reason:  apiv1.ConditionClusterSetErrorReconcile,
 			Status:  metav1.ConditionTrue,
-			Reason:  "ReconcileError",
 			Message: fmt.Sprintf("Error during reconcile: %s", rErr.Error()),
 		}
 

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -203,7 +203,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionClusterSetReady,
 				Status:  metav1.ConditionUnknown,
-				Message: "Error connecting to primary cluster",
+				Message: fmt.Sprintf("Error connecting to primary cluster: %s", rErr.Error()),
 				Reason:  "ClusterSetManagerError",
 			})
 		}

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -93,12 +93,14 @@ func enqueueFromCredentialsSecret(c client.Client) handler.EventHandler {
 		if !ok {
 			return nil
 		}
-		list := &apiv1.PerconaServerMySQLList{}
+
 		log := logf.FromContext(ctx)
+
+		list := &apiv1.PerconaServerMySQLClusterSetList{}
 		if err := c.List(ctx, list, client.InNamespace(secret.Namespace), client.MatchingFields{
 			fieldSecretsName: secret.Name,
 		}); err != nil {
-			log.Error(err, "failed to list clusters for secret", "secret", secret.Name)
+			log.Error(err, "failed to list ps-clustersets with matching spec.credentialsSecret.name", "secret", secret.Name)
 			return nil
 		}
 

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -197,6 +197,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 		// without connecting to the primary cluster, we no longer know for sure if
 		// everything is up and running correctly.
 		if errors.Is(rErr, errGetClusterSetManager) {
+			markAllNodesUnknown(status)
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionClusterSetReady,
 				Status:  metav1.ConditionUnknown,

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -79,6 +79,8 @@ func (r *PerconaServerMySQLClusterSetReconciler) SetupWithManager(mgr ctrl.Manag
 		Complete(r)
 }
 
+var errGetClusterSetManager = errors.New("get cluster set manager")
+
 //+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqlclustersets;perconaservermysqlclustersets/status;perconaservermysqlclustersets/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the PerconaServerMySQLClusterSet custom resource.
@@ -99,146 +101,115 @@ func (r *PerconaServerMySQLClusterSetReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, r.reconcileFinalizers(ctx, pcs)
 	}
 
-	if err := r.reconcileRBAC(ctx, pcs); err != nil {
+	var err error
+	defer func() {
+		if updErr := r.reconcileErrorCondition(ctx, pcs, err); updErr != nil {
+			err = errors.Wrap(updErr, "reconcile error condition")
+		}
+	}()
+
+	if err = r.reconcileRBAC(ctx, pcs); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "reconcile RBAC")
 	}
 
-	if ready, err := r.reconcileMySQLShellRunner(ctx, pcs); err != nil {
+	if err = r.cleanupOutdatedJobs(ctx, pcs); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "cleanup outdated jobs")
+	}
+
+	var runnerReady bool
+	if runnerReady, err = r.reconcileMySQLShellRunner(ctx, pcs); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "reconcile MySQLShellRunner")
-	} else if !ready {
+	} else if !runnerReady {
 		log.Info("Waiting for mysqlshell runner to be ready")
 		return ctrl.Result{}, nil
 	}
 
-	manager, err := r.getClusterSetManager(ctx, pcs)
-	if updErr := r.handleClusterSetManagerError(ctx, pcs, err); updErr != nil {
-		return ctrl.Result{}, errors.Wrap(updErr, "handle cluster set manager error")
-	}
-
+	var manager ClusterSetManager
+	manager, err = r.getClusterSetManager(ctx, pcs)
 	if errors.Is(err, mysqlsh.ErrEndpointUnreachable) {
 		if err := r.reconcileForcedFailover(ctx, pcs); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "reconcile forced failover")
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	} else if err != nil {
+		err = fmt.Errorf("%w: %w", errGetClusterSetManager, err)
+		return ctrl.Result{}, err
 	}
 
-	if err := r.bootstrapClusterSet(ctx, pcs, manager); err != nil {
+	if err = r.bootstrapClusterSet(ctx, pcs, manager); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "bootstrap ClusterSet")
 	}
 
-	if err := r.reconcileReplicas(ctx, pcs); err != nil {
+	if err = r.reconcileReplicas(ctx, pcs); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "reconcile replicas")
 	}
 
-	if err := r.reconcileSwitchover(ctx, pcs); err != nil {
+	if err = r.reconcileSwitchover(ctx, pcs); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "reconcile switchover")
 	}
 
-	if err := r.reconcileStatus(ctx, pcs, manager); err != nil {
+	if err = r.reconcileStatus(ctx, pcs, manager); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "reconcile status")
-	}
-
-	if err := r.cleanupOutdatedJobs(ctx, pcs); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "cleanup outdated jobs")
 	}
 
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (r *PerconaServerMySQLClusterSetReconciler) handleClusterSetManagerError(
+func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondition(
 	ctx context.Context,
 	pcs *apiv1.PerconaServerMySQLClusterSet,
-	csErr error,
+	rErr error,
 ) error {
-	if err := r.reconcileErrorCondAccessDenied(ctx, pcs, csErr); err != nil {
-		return errors.Wrap(err, "reconcile access denied condition")
+	markAllNodesUnknown := func(status *apiv1.PerconaServerMySQLClusterSetStatus) {
+		for name, c := range status.Clusters {
+			c.GlobalStatus = clusterset.StatusUnknown
+			status.Clusters[name] = c
+		}
 	}
-	if err := r.reconcileErrorCondPrimaryUnreachable(ctx, pcs, csErr); err != nil {
-		return errors.Wrap(err, "reconcile primary cluster unreachable condition")
-	}
-	return nil
-}
 
-func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondAccessDenied(
-	ctx context.Context,
-	pcs *apiv1.PerconaServerMySQLClusterSet,
-	csErr error,
-) error {
-	if errors.Is(csErr, mysqlsh.ErrAccessDenied) {
-		return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-			for name, c := range status.Clusters {
-				c.GlobalStatus = clusterset.StatusUnknown
-				status.Clusters[name] = c
-			}
+	if updErr := pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
+		if rErr == nil {
+			meta.RemoveStatusCondition(&status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+			return nil
+		}
+
+		cond := metav1.Condition{
+			Type:    apiv1.ConditionClusterSetErrorReconcile,
+			Status:  metav1.ConditionTrue,
+			Message: rErr.Error(),
+			Reason:  "ReconcileError",
+		}
+
+		// handle known failures
+		switch {
+		case errors.Is(rErr, mysqlsh.ErrAccessDenied):
+			cond.Reason = "AccessDenied"
+			cond.Message = "Access denied on primary, check the clusterset credentials"
+			markAllNodesUnknown(status)
+		case errors.Is(rErr, mysqlsh.ErrEndpointUnreachable):
+			cond.Reason = "PrimaryClusterUnreachable"
+			cond.Message = "Primary cluster is unreachable, check the network and cluster status"
+			markAllNodesUnknown(status)
+		}
+
+		meta.SetStatusCondition(&status.Conditions, cond)
+
+		// without connecting to the primary cluster, we no longer know for sure if
+		// everything is up and running correctly.
+		if errors.Is(rErr, errGetClusterSetManager) {
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:    apiv1.ConditionClusterSetReady,
-				Status:  metav1.ConditionFalse,
-				Reason:  "AccessDenied",
-				Message: "Invalid credentials for clusterset user",
+				Status:  metav1.ConditionUnknown,
+				Message: "Error connecting to primary cluster",
+				Reason:  "ClusterSetManagerError",
 			})
-			return nil
-		})
+		}
+		return nil
+
+	}); updErr != nil {
+		return errors.Wrap(updErr, "update status")
 	}
 	return nil
-}
-
-func (r *PerconaServerMySQLClusterSetReconciler) reconcileErrorCondPrimaryUnreachable(
-	ctx context.Context,
-	pcs *apiv1.PerconaServerMySQLClusterSet,
-	csErr error,
-) error {
-	if errors.Is(csErr, mysqlsh.ErrEndpointUnreachable) {
-		return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-			for name, c := range status.Clusters {
-				c.GlobalStatus = clusterset.StatusUnknown
-				status.Clusters[name] = c
-			}
-			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:    apiv1.ConditionPrimaryClusterUnreachable,
-				Status:  metav1.ConditionTrue,
-				Reason:  apiv1.ConditionPrimaryClusterUnreachable,
-				Message: "All primary cluster endpoints are unreachable",
-			})
-			return nil
-		})
-	}
-
-	cond := meta.FindStatusCondition(pcs.Status.Conditions, apiv1.ConditionPrimaryClusterUnreachable)
-	if cond == nil {
-		return nil
-	}
-
-	return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-		meta.RemoveStatusCondition(&status.Conditions, apiv1.ConditionPrimaryClusterUnreachable)
-		return nil
-	})
-}
-
-// mysqlErrAccessDenied is MySQL error code 1045 (ER_ACCESS_DENIED_ERROR),
-// reported when the clusterset user authenticates with invalid credentials.
-const mysqlErrAccessDenied = "1045"
-
-// reconcileInvalidCredentialsCondition sets ClusterSetReady=False when the
-// ClusterSet manager error indicates the clusterset user's credentials were
-// rejected. Other errors leave the conditions untouched.
-func (r *PerconaServerMySQLClusterSetReconciler) reconcileInvalidCredentialsCondition(
-	ctx context.Context,
-	pcs *apiv1.PerconaServerMySQLClusterSet,
-	csErr error,
-) error {
-	if !strings.Contains(csErr.Error(), mysqlErrAccessDenied) {
-		return nil
-	}
-
-	return pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-			Type:    apiv1.ConditionClusterSetReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  "AccessDenied",
-			Message: "Invalid credentials for clusterset user",
-		})
-		return nil
-	})
 }
 
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/psclusterset/controller_test.go
+++ b/pkg/controller/psclusterset/controller_test.go
@@ -746,7 +746,7 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 					{
 						Type:    apiv1.ConditionClusterSetErrorReconcile,
 						Status:  metav1.ConditionTrue,
-						Reason:  "ReconcileError",
+						Reason:  apiv1.ConditionClusterSetErrorReconcile,
 						Message: "some earlier failure",
 					},
 				}
@@ -768,7 +768,7 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
 				require.NotNil(t, cond)
 				assert.Equal(t, metav1.ConditionTrue, cond.Status)
-				assert.Equal(t, "ReconcileError", cond.Reason)
+				assert.Equal(t, apiv1.ConditionClusterSetErrorReconcile, cond.Reason)
 				assert.Equal(t, "Error during reconcile: reconcile replicas failed", cond.Message)
 
 				// node statuses are untouched for unknown failures

--- a/pkg/controller/psclusterset/controller_test.go
+++ b/pkg/controller/psclusterset/controller_test.go
@@ -1,12 +1,15 @@
 package psclusterset
 
 import (
+	"fmt"
 	"testing"
 
 	apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
 	"github.com/percona/percona-server-mysql-operator/pkg/clusterset"
 	psmock "github.com/percona/percona-server-mysql-operator/pkg/controller/psclusterset/mock"
+	"github.com/percona/percona-server-mysql-operator/pkg/mysqlsh"
 	"github.com/percona/percona-server-mysql-operator/pkg/naming"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
@@ -698,6 +701,170 @@ func TestReconciler_reconcileReplicas(t *testing.T) {
 			err := r.reconcileReplicas(t.Context(), clusterSet)
 			require.NoError(t, err)
 			tc.asserts(t, cl)
+		})
+	}
+}
+
+func TestReconciler_reconcileErrorCondition(t *testing.T) {
+	// clusterSetWithStatus returns a copy of baseClusterSet with both member
+	// clusters reporting a healthy global status, so tests can assert when the
+	// reconciler marks them UNKNOWN.
+	clusterSetWithStatus := func() *apiv1.PerconaServerMySQLClusterSet {
+		pcs := baseClusterSet.DeepCopy()
+		pcs.Status.Clusters = apiv1.ClusterSetStatus{
+			"dc1": {
+				ClusterRole:  clusterset.ClusterRolePrimary,
+				GlobalStatus: "OK",
+			},
+			"dc2": {
+				ClusterRole:  clusterset.ClusterRoleReplica,
+				GlobalStatus: "OK",
+			},
+		}
+		return pcs
+	}
+
+	assertNodesUnknown := func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+		t.Helper()
+		require.NotEmpty(t, observed.Status.Clusters)
+		for name, c := range observed.Status.Clusters {
+			assert.Equal(t, clusterset.StatusUnknown, c.GlobalStatus, "cluster %s should be marked unknown", name)
+		}
+	}
+
+	testCases := []struct {
+		desc       string
+		clusterSet func() *apiv1.PerconaServerMySQLClusterSet
+		rErr       error
+		asserts    func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet)
+	}{
+		{
+			desc: "nil error removes the error condition",
+			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
+				pcs := baseClusterSet.DeepCopy()
+				pcs.Status.Conditions = []metav1.Condition{
+					{
+						Type:    apiv1.ConditionClusterSetErrorReconcile,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ReconcileError",
+						Message: "some earlier failure",
+					},
+				}
+				return pcs
+			},
+			rErr: nil,
+			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				assert.Nil(t, cond)
+			},
+		},
+		{
+			desc: "generic error sets the error condition",
+			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
+				return clusterSetWithStatus()
+			},
+			rErr: errors.New("reconcile replicas failed"),
+			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				require.NotNil(t, cond)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, "ReconcileError", cond.Reason)
+				assert.Equal(t, "reconcile replicas failed", cond.Message)
+
+				// node statuses are untouched for unknown failures
+				for _, c := range observed.Status.Clusters {
+					assert.Equal(t, "OK", c.GlobalStatus)
+				}
+			},
+		},
+		{
+			desc: "access denied error marks nodes unknown",
+			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
+				return clusterSetWithStatus()
+			},
+			rErr: fmt.Errorf("create cluster set: %w", mysqlsh.ErrAccessDenied),
+			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				require.NotNil(t, cond)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, "AccessDenied", cond.Reason)
+				assert.Equal(t, "Access denied on primary, check the clusterset credentials", cond.Message)
+				assertNodesUnknown(t, observed)
+			},
+		},
+		{
+			desc: "endpoint unreachable error marks nodes unknown",
+			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
+				return clusterSetWithStatus()
+			},
+			rErr: fmt.Errorf("status: %w", mysqlsh.ErrEndpointUnreachable),
+			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				require.NotNil(t, cond)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, "PrimaryClusterUnreachable", cond.Reason)
+				assert.Equal(t, "Primary cluster is unreachable, check the network and cluster status", cond.Message)
+				assertNodesUnknown(t, observed)
+			},
+		},
+		{
+			desc: "cluster set manager error marks ready unknown",
+			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
+				pcs := clusterSetWithStatus()
+				pcs.Status.Conditions = []metav1.Condition{
+					{
+						Type:   apiv1.ConditionClusterSetReady,
+						Status: metav1.ConditionTrue,
+						Reason: "ClusterSetHealthy",
+					},
+				}
+				return pcs
+			},
+			rErr: fmt.Errorf("%w: %s", errGetClusterSetManager, "connection refused"),
+			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
+				errCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				require.NotNil(t, errCond)
+				assert.Equal(t, metav1.ConditionTrue, errCond.Status)
+				assert.Equal(t, "ReconcileError", errCond.Reason)
+
+				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
+				require.NotNil(t, readyCond)
+				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
+				assert.Equal(t, "ClusterSetManagerError", readyCond.Reason)
+				assert.Equal(t, "Error connecting to primary cluster", readyCond.Message)
+				assertNodesUnknown(t, observed)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := clientgoscheme.AddToScheme(scheme); err != nil {
+				t.Fatal(err, "failed to add client-go scheme")
+			}
+			if err := apiv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err, "failed to add apis scheme")
+			}
+
+			clusterSet := tc.clusterSet()
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(clusterSet).
+				WithStatusSubresource(clusterSet).
+				Build()
+
+			r := &PerconaServerMySQLClusterSetReconciler{
+				Client: cl,
+				Scheme: scheme,
+			}
+			err := r.reconcileErrorCondition(t.Context(), clusterSet, tc.rErr)
+			require.NoError(t, err)
+
+			observed := &apiv1.PerconaServerMySQLClusterSet{}
+			err = cl.Get(t.Context(), client.ObjectKeyFromObject(baseClusterSet), observed)
+			require.NoError(t, err)
+			tc.asserts(t, observed)
 		})
 	}
 }

--- a/pkg/controller/psclusterset/controller_test.go
+++ b/pkg/controller/psclusterset/controller_test.go
@@ -6,8 +6,8 @@ import (
 
 	apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
 	"github.com/percona/percona-server-mysql-operator/pkg/clusterset"
+	csmanager "github.com/percona/percona-server-mysql-operator/pkg/clusterset/manager"
 	psmock "github.com/percona/percona-server-mysql-operator/pkg/controller/psclusterset/mock"
-	"github.com/percona/percona-server-mysql-operator/pkg/mysqlsh"
 	"github.com/percona/percona-server-mysql-operator/pkg/naming"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
@@ -769,7 +769,7 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, metav1.ConditionTrue, cond.Status)
 				assert.Equal(t, "ReconcileError", cond.Reason)
-				assert.Equal(t, "reconcile replicas failed", cond.Message)
+				assert.Equal(t, "Error during reconcile: reconcile replicas failed", cond.Message)
 
 				// node statuses are untouched for unknown failures
 				for _, c := range observed.Status.Clusters {
@@ -782,18 +782,20 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
 				return clusterSetWithStatus()
 			},
-			rErr: fmt.Errorf("create cluster set: %w", mysqlsh.ErrAccessDenied),
+			rErr: fmt.Errorf("%w: %w", errGetClusterSetManager, csmanager.NewAccessDeniedError()),
 			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
 				errCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
 				require.NotNil(t, errCond)
 				assert.Equal(t, metav1.ConditionTrue, errCond.Status)
 				assert.Equal(t, "AccessDenied", errCond.Reason)
-				assert.Equal(t, "Access denied on primary, check the clusterset credentials", errCond.Message)
+				assert.Equal(t, "Invalid credentials for the primary cluster", errCond.Message)
 				assertNodesUnknown(t, observed)
 
 				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
 				require.NotNil(t, readyCond)
 				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
+				assert.Equal(t, "AccessDenied", readyCond.Reason)
+				assert.Equal(t, "Invalid credentials for the primary cluster", readyCond.Message)
 			},
 		},
 		{
@@ -801,18 +803,20 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 			clusterSet: func() *apiv1.PerconaServerMySQLClusterSet {
 				return clusterSetWithStatus()
 			},
-			rErr: fmt.Errorf("status: %w", mysqlsh.ErrEndpointUnreachable),
+			rErr: csmanager.NewUnreachableError(),
 			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
 				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
 				require.NotNil(t, cond)
 				assert.Equal(t, metav1.ConditionTrue, cond.Status)
-				assert.Equal(t, "PrimaryClusterUnreachable", cond.Reason)
-				assert.Equal(t, "Primary cluster is unreachable, check the network and cluster status", cond.Message)
+				assert.Equal(t, "PrimaryUnreachable", cond.Reason)
+				assert.Equal(t, "No reachable endpoint for the primary cluster", cond.Message)
 				assertNodesUnknown(t, observed)
 
 				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
 				require.NotNil(t, readyCond)
 				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
+				assert.Equal(t, "PrimaryUnreachable", readyCond.Reason)
+				assert.Equal(t, "No reachable endpoint for the primary cluster", readyCond.Message)
 			},
 		},
 		{
@@ -828,18 +832,19 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 				}
 				return pcs
 			},
-			rErr: fmt.Errorf("%w: %s", errGetClusterSetManager, "connection refused"),
+			rErr: fmt.Errorf("%w: %w", errGetClusterSetManager, csmanager.NewGenericError("connection refused")),
 			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
 				errCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
 				require.NotNil(t, errCond)
 				assert.Equal(t, metav1.ConditionTrue, errCond.Status)
-				assert.Equal(t, "ReconcileError", errCond.Reason)
+				assert.Equal(t, "ClusterSetManagerError", errCond.Reason)
+				assert.Equal(t, "connection refused", errCond.Message)
 
 				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
 				require.NotNil(t, readyCond)
 				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
 				assert.Equal(t, "ClusterSetManagerError", readyCond.Reason)
-				assert.Contains(t, readyCond.Message, "Error connecting to primary cluster")
+				assert.Equal(t, "connection refused", readyCond.Message)
 				assertNodesUnknown(t, observed)
 			},
 		},

--- a/pkg/controller/psclusterset/controller_test.go
+++ b/pkg/controller/psclusterset/controller_test.go
@@ -839,7 +839,7 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 				require.NotNil(t, readyCond)
 				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
 				assert.Equal(t, "ClusterSetManagerError", readyCond.Reason)
-				assert.Equal(t, "Error connecting to primary cluster", readyCond.Message)
+				assert.Contains(t, readyCond.Message, "Error connecting to primary cluster")
 				assertNodesUnknown(t, observed)
 			},
 		},

--- a/pkg/controller/psclusterset/controller_test.go
+++ b/pkg/controller/psclusterset/controller_test.go
@@ -784,12 +784,16 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 			},
 			rErr: fmt.Errorf("create cluster set: %w", mysqlsh.ErrAccessDenied),
 			asserts: func(t *testing.T, observed *apiv1.PerconaServerMySQLClusterSet) {
-				cond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
-				require.NotNil(t, cond)
-				assert.Equal(t, metav1.ConditionTrue, cond.Status)
-				assert.Equal(t, "AccessDenied", cond.Reason)
-				assert.Equal(t, "Access denied on primary, check the clusterset credentials", cond.Message)
+				errCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetErrorReconcile)
+				require.NotNil(t, errCond)
+				assert.Equal(t, metav1.ConditionTrue, errCond.Status)
+				assert.Equal(t, "AccessDenied", errCond.Reason)
+				assert.Equal(t, "Access denied on primary, check the clusterset credentials", errCond.Message)
 				assertNodesUnknown(t, observed)
+
+				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
+				require.NotNil(t, readyCond)
+				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
 			},
 		},
 		{
@@ -805,6 +809,10 @@ func TestReconciler_reconcileErrorCondition(t *testing.T) {
 				assert.Equal(t, "PrimaryClusterUnreachable", cond.Reason)
 				assert.Equal(t, "Primary cluster is unreachable, check the network and cluster status", cond.Message)
 				assertNodesUnknown(t, observed)
+
+				readyCond := meta.FindStatusCondition(observed.Status.Conditions, apiv1.ConditionClusterSetReady)
+				require.NotNil(t, readyCond)
+				assert.Equal(t, metav1.ConditionUnknown, readyCond.Status)
 			},
 		},
 		{

--- a/pkg/mysqlsh/mysqlshexec.go
+++ b/pkg/mysqlsh/mysqlshexec.go
@@ -263,7 +263,10 @@ func (m *MysqlshExec) ClusterSetStatusWithExec(ctx context.Context) (clusterset.
 	return status, nil
 }
 
-var ErrEndpointUnreachable = errors.New("endpoint unreachable")
+var (
+	ErrEndpointUnreachable = errors.New("endpoint unreachable")
+	ErrAccessDenied        = errors.New("access denied")
+)
 
 func (m *MysqlshExec) Ping(ctx context.Context) error {
 	var outb, errb bytes.Buffer
@@ -275,9 +278,25 @@ func (m *MysqlshExec) Ping(ctx context.Context) error {
 		if isEndpointUnreachable(err, outb.String(), errb.String()) {
 			return ErrEndpointUnreachable
 		}
+		if isAccessDenied(err, outb.String(), errb.String()) {
+			return ErrAccessDenied
+		}
 		return errors.Wrapf(err, "ping, stdout: %s, stderr: %s", outb.String(), errb.String())
 	}
 	return nil
+}
+
+func isAccessDenied(err error, stdout, stderr string) bool {
+	msg := strings.ToLower(strings.Join([]string{err.Error(), stdout, stderr}, "\n"))
+	accessDeniedMessages := []string{
+		"MySQL Error 1045",
+	}
+	for _, text := range accessDeniedMessages {
+		if strings.Contains(msg, strings.ToLower(text)) {
+			return true
+		}
+	}
+	return false
 }
 
 func isEndpointUnreachable(err error, stdout, stderr string) bool {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

* Adds a new condition `ErrorReconcile` to ps-clusterset status, with 2 known failure reasons `AccessDenied` and `PrimaryUnreachable` (the previous condition type `PrimaryClusterUnreachable` is removed)
* All clusters in `.status.clusters` get an `UNKNOWN` status when the controller cannot establish a connection to the primary cluster
* Improved `pcs.UpdateStatus` retry, the previous default was too short and resulted in frequent conflict errors
* the `AwaitingExternalBootstrap` condition in `ps` status kept refreshing, now it is added only when needed

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
