### PR TITLE
K8SPS-780 Add Mysql 9.7 support

### DIFF
--- a/build/ps-entrypoint.sh
+++ b/build/ps-entrypoint.sh
@@ -212,7 +212,7 @@ create_default_cnf() {
 		sed -i "/\[mysqld\]/a innodb_parallel_dblwr_encrypt=ON" $CFG
 	fi
 
-	if [ "$MYSQL_VERSION" == '8.4' ]; then
+	if [ "$MYSQL_VERSION" == '8.4' ] || [ "$MYSQL_VERSION" == '9.7' ]; then
 		sed -i "/\[mysqld\]/a innodb_numa_interleave=OFF" $CFG
 	fi
 
@@ -254,7 +254,7 @@ escape_special() {
 
 MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-if [[ "$MYSQL_VERSION" != '8.0' ]] && [[ "${MYSQL_VERSION}" != '8.4' ]]; then
+if [[ "$MYSQL_VERSION" != '8.0' ]] && [[ "${MYSQL_VERSION}" != '8.4' ]] && [[ "${MYSQL_VERSION}" != '9.7' ]]; then
 	echo "Percona Distribution for MySQL Operator does not support $MYSQL_VERSION"
 	exit 1
 fi
@@ -476,7 +476,7 @@ if [ "$1" = 'mysqld' ] && [ -z "$wantHelp" ]; then
 	fi
 fi
 
-if [[ ${MYSQL_VERSION} == '8.4' ]]; then
+if [[ ${MYSQL_VERSION} == '8.4' || ${MYSQL_VERSION} == '9.7' ]]; then
   # if vault secret file exists we assume we need to turn on encryption
   if [[ -f ${KEYRING_VAULT_PATH} ]]; then
     install_keyring_component

--- a/build/run-restore.sh
+++ b/build/run-restore.sh
@@ -58,7 +58,7 @@ get_keyring_arg() {
 		if [[ ${XTRABACKUP_VERSION} == "8.0" ]]; then
 			echo "Using keyring vault config: ${KEYRING_VAULT_PATH}" >&2
 			keyring="--keyring-vault-config=${KEYRING_VAULT_PATH}"
-		elif [[ ${XTRABACKUP_VERSION} == "8.4" ]]; then
+		elif [[ ${XTRABACKUP_VERSION} == "8.4" || ${XTRABACKUP_VERSION} == 9.* ]]; then
 			cp "${KEYRING_VAULT_PATH}" /tmp/component_keyring_vault.cnf
 			echo "Using keyring vault component: /tmp/component_keyring_vault.cnf" >&2
 			keyring="--component-keyring-config=/tmp/component_keyring_vault.cnf"

--- a/e2e-tests/tests/gr-init-deploy/11-check-numa.yaml
+++ b/e2e-tests/tests/gr-init-deploy/11-check-numa.yaml
@@ -7,8 +7,8 @@ commands:
 
       source ../../functions
 
-      if [ "${MYSQL_VERSION}" != "8.4" ]; then
-          echo "skip: innodb_numa_interleave is only disabled by default for 8.4"
+      if [ "${MYSQL_VERSION}" != "8.4" ] && [ "${MYSQL_VERSION}" != "9.7" ]; then
+          echo "skip: innodb_numa_interleave is only disabled by default for 8.4 and 9.7"
           exit 0
       fi
 

--- a/e2e-tests/tests/init-deploy/08-check-numa.yaml
+++ b/e2e-tests/tests/init-deploy/08-check-numa.yaml
@@ -7,8 +7,8 @@ commands:
 
       source ../../functions
 
-      if [ "${MYSQL_VERSION}" != "8.4" ]; then
-          echo "skip: innodb_numa_interleave is only disabled by default for 8.4"
+      if [ "${MYSQL_VERSION}" != "8.4" ] && [ "${MYSQL_VERSION}" != "9.7" ]; then
+          echo "skip: innodb_numa_interleave is only disabled by default for 8.4 and 9.7"
           exit 0
       fi
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Solution:**
Improve validations to allow MySQL 9.7 deployments 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
