### PR TITLE
AIK-13: [bugfix] allow clearing group replication seeds

### DIFF
--- a/cmd/bootstrap/gr/group_replication.go
+++ b/cmd/bootstrap/gr/group_replication.go
@@ -203,7 +203,7 @@ func (m *mysqlsh) getGTIDPurged(ctx context.Context) (string, error) {
 }
 
 func (m *mysqlsh) setGroupSeeds(ctx context.Context, seeds string) error {
-	if !seedsRegexp.MatchString(seeds) {
+	if seeds != "" && !seedsRegexp.MatchString(seeds) {
 		return errors.Errorf("invalid group_replication_group_seeds value %q", seeds)
 	}
 	sql := fmt.Sprintf("SET PERSIST group_replication_group_seeds = '%s'", seeds)


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

Addresses this comment - https://github.com/percona/percona-server-mysql-operator/pull/1415#discussion_r3451855052

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
