### PR TITLE
K8SPS-508: update default clusterset recovery method

### DIFF
--- a/api/v1/perconaservermysqlclusterset_types.go
+++ b/api/v1/perconaservermysqlclusterset_types.go
@@ -125,7 +125,7 @@ func (ucs *UnsafeClusterSetFlags) SetDefaults() {
 
 func (pcs *PerconaServerMySQLClusterSet) SetDefaults() {
 	if pcs.Spec.CreateReplicaClusterOptions.RecoveryMethod == "" {
-		pcs.Spec.CreateReplicaClusterOptions.RecoveryMethod = RecoveryMethodClone
+		pcs.Spec.CreateReplicaClusterOptions.RecoveryMethod = RecoveryMethodAuto
 	}
 
 	if pcs.Spec.UnsafeClusterSetFlags == nil {
@@ -156,12 +156,12 @@ const (
 
 type CreateReplicaClusterOptions struct {
 	// Preferred method for state recovery/provisioning.
-	// Default is 'clone'.
+	// Default is 'auto'.
 	// Set this to 'incremental' when the cluster is seeded from an existing backup.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=clone;incremental;auto
-	// +kubebuilder:default:=clone
+	// +kubebuilder:default:=auto
 	RecoveryMethod RecoveryMethod `json:"recoveryMethod"`
 }
 

--- a/config/crd/bases/ps.percona.com_perconaservermysqlclustersets.yaml
+++ b/config/crd/bases/ps.percona.com_perconaservermysqlclustersets.yaml
@@ -83,7 +83,7 @@ spec:
               createReplicaClusterOptions:
                 properties:
                   recoveryMethod:
-                    default: clone
+                    default: auto
                     enum:
                     - clone
                     - incremental

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1317,7 +1317,7 @@ spec:
               createReplicaClusterOptions:
                 properties:
                   recoveryMethod:
-                    default: clone
+                    default: auto
                     enum:
                     - clone
                     - incremental

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1317,7 +1317,7 @@ spec:
               createReplicaClusterOptions:
                 properties:
                   recoveryMethod:
-                    default: clone
+                    default: auto
                     enum:
                     - clone
                     - incremental

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -1317,7 +1317,7 @@ spec:
               createReplicaClusterOptions:
                 properties:
                   recoveryMethod:
-                    default: clone
+                    default: auto
                     enum:
                     - clone
                     - incremental


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

Set the default recovery method to `auto` to match with mysqlshell defaults

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
