### PR TITLE
K8SPS-508 set HOME=/tmp on mysqlshell-runner Deployment

### DIFF
--- a/pkg/clusterset/mysqlshel_runner.go
+++ b/pkg/clusterset/mysqlshel_runner.go
@@ -47,6 +47,10 @@ func MySQLShellRunner(pcs *apiv1.PerconaServerMySQLClusterSet) *appsv1.Deploymen
 							Command: []string{"sleep", "infinity"},
 							Env: []corev1.EnvVar{
 								{
+									Name:  "HOME",
+									Value: "/tmp",
+								},
+								{
 									Name: MySQLShellRunnerPassword,
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: pcs.Spec.CredentialsSecret.DeepCopy(),

--- a/pkg/clusterset/mysqlshel_runner_test.go
+++ b/pkg/clusterset/mysqlshel_runner_test.go
@@ -51,8 +51,20 @@ func TestMySQLShellRunner(t *testing.T) {
 	assert.Equal(t, "percona/percona-server-mysql-operator:mysqlshell", containers[0].Image)
 	assert.Equal(t, []string{"sleep", "infinity"}, containers[0].Command)
 	assert.Equal(t, corev1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
+
+	envByName := map[string]corev1.EnvVar{}
+	for _, e := range containers[0].Env {
+		envByName[e.Name] = e
+	}
+
+	homeEnv, ok := envByName["HOME"]
+	assert.True(t, ok, "HOME env var must be set so mysqlsh can write its ~/.mysqlsh directory")
+	assert.Equal(t, "/tmp", homeEnv.Value)
+
+	pwEnv, ok := envByName[MySQLShellRunnerPassword]
+	assert.True(t, ok, "%s env var must be set from the credentials secret", MySQLShellRunnerPassword)
 	assert.Equal(t, corev1.SecretKeySelector{
 		LocalObjectReference: corev1.LocalObjectReference{Name: "clusterset-creds"},
 		Key:                  "password",
-	}, *containers[0].Env[0].ValueFrom.SecretKeyRef)
+	}, *pwEnv.ValueFrom.SecretKeyRef)
 }


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

**Solution:**
mysqlsh tries to create $HOME/.mysqlsh on startup to hold its session config and history. The mysqlshell-runner Deployment runs the operator image as a non-root user with HOME unset, so mysqlsh resolves the path to //.mysqlsh and fails with "Permission denied" trying to write to the container root. The reconcile then sticks on ClusterSetManagerError and the ClusterSet never reaches Ready. Set HOME=/tmp explicitly on the runner container. /tmp is always writable for any container user, mysqlsh creates /tmp/.mysqlsh there, and the existing exec-based mysqlsh callers in pkg/mysqlsh do not need to change because they target this same pod.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
