### PR TITLE
K8SPS-731 Automatically use k8s min version in PR job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,13 +8,19 @@ void createCluster(String CLUSTER_SUFFIX) {
             export KUBECONFIG=/tmp/$CLUSTER_NAME-${CLUSTER_SUFFIX}
             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
+            GKE_VERSION=\$(gcloud container get-server-config --zone $region --flatten='channels[].validVersions[]' --filter='channels.channel=STABLE' --format='value(channels.validVersions)' | sort -V | head -n1)
+            if [ -z "\${GKE_VERSION}" ]; then
+                echo "Failed to detect the minimum Kubernetes version from the GKE stable release channel"
+                exit 1
+            fi
             ret_num=0
             while [ \${ret_num} -lt 15 ]; do
                 ret_val=0
                 gcloud container clusters list --filter $CLUSTER_NAME-${CLUSTER_SUFFIX} --zone $region --format='csv[no-heading](name)' | xargs gcloud container clusters delete --zone $region --quiet || true
+                echo "Creating GKE cluster $CLUSTER_NAME-${CLUSTER_SUFFIX} with Kubernetes version \${GKE_VERSION} from the stable release channel"
                 gcloud container clusters create $CLUSTER_NAME-${CLUSTER_SUFFIX} \
                     --zone $region \
-                    --cluster-version=1.33 \
+                    --cluster-version="\${GKE_VERSION}" \
                     --machine-type=c2d-standard-4 \
                     --preemptible \
                     --disk-size 30 \


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
PR job fail when min k8s version is dropped.

**Solution:**
Get the min supported k8s version from GKE stable channel automatically.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
