### PR TITLE
K8SPS-854: fix stuck incremental backups due to state informer cache read

### DIFF
--- a/pkg/controller/psbackup/controller.go
+++ b/pkg/controller/psbackup/controller.go
@@ -347,12 +347,15 @@ func (r *PerconaServerMySQLBackupReconciler) prepareStatus(
 	status *apiv1.PerconaServerMySQLBackupStatus,
 	backupSource string,
 ) error {
-	destination, err := xtrabackup.GetDestination(storage, cr, time.Now())
-	if err != nil {
-		return errors.Wrap(err, "get backup destination")
+	if status.Destination == "" {
+		destination, err := xtrabackup.GetDestination(storage, cr, time.Now())
+		if err != nil {
+			return errors.Wrap(err, "get backup destination")
+		}
+		status.Destination = destination
+
 	}
 
-	status.Destination = destination
 	status.Image = cluster.Spec.Backup.Image
 	status.Storage = storage.DeepCopy()
 	status.BackupSource = backupSource


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
#### Problem:

Incremental backups get stuck when trying to get checkpoint info of previous backup.

#### Cause:

A successful incremental backup has different name on `status.destination` from what is actually uploaded. For example, from a live repro of this bug we have:
* on `status.destionation` -> `gs-xtrabackup-2026-08-12-12:30:45-incr`
* actual file on s3 -> `gs-xtrabackup-2026-08-12-12:30:44-incr`

Note how there is a difference of 1 second in the name. This causes `GetCheckpointInfo` to fail on the next backup because it tries to locate what is on `status.destination`, but that file doesn't exist.

**Why the status differs**

`status.destination` is derived from `time.Now()`, so it must be computed exactly once per backup. The intended guard is the Job lookup: the destination is only computed on the branch where the Job doesn't exist yet (`k8serrors.IsNotFound`). That guard doesn't hold, because the Job is read from the informer cache. If a reconcile runs before the cache catches up on a Job we just created, we take the not-found branch a second time and recompute the destination — and if the wall clock has crossed a second boundary since the first computation, the recomputed path differs. We overwrite `status.destination` with it while the Job is already running against the original path. The result is a recorded destination that doesn't match what was uploaded.


#### Solution:

Add an extra check that `status.destination` is empty before writing to it. If the CR itself is read from a stale informer cache, the existing status update object protects us from overwriting status.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
