### PR TITLE
K8SPS-849: additional binlog server keyring validation

### DIFF
--- a/cmd/pitr/decrypt.go
+++ b/cmd/pitr/decrypt.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/percona/percona-server-mysql-operator/pkg/binlogserver"
 )
@@ -78,7 +77,7 @@ type decryptedReadCloser struct {
 }
 
 func unwrapFileKey(env *binlogserver.FileKeyEnvelope, kek binlogserver.Key) ([]byte, error) {
-	keySize, mode, err := parseCipher(kek.Cipher)
+	keySize, mode, err := binlogserver.ParseCipher(kek.Cipher)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +131,18 @@ func unwrapFileKey(env *binlogserver.FileKeyEnvelope, kek binlogserver.Key) ([]b
 		cipher.NewCBCDecrypter(block, iv).CryptBlocks(fileKey, wrapped)
 		return fileKey, nil
 
+	case "CTR":
+		iv, err := hex.DecodeString(env.IVHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode file key IV: %w", err)
+		}
+		if len(iv) != blockSize {
+			return nil, fmt.Errorf("file key IV is %d bytes, %s needs %d", len(iv), kek.Cipher, blockSize)
+		}
+		fileKey := make([]byte, len(wrapped))
+		cipher.NewCTR(block, iv).XORKeyStream(fileKey, wrapped)
+		return fileKey, nil
+
 	case "GCM":
 		iv, err := hex.DecodeString(env.IVHex)
 		if err != nil {
@@ -165,7 +176,7 @@ func unwrapFileKey(env *binlogserver.FileKeyEnvelope, kek binlogserver.Key) ([]b
 }
 
 func dataStream(env *binlogserver.FileDataEnvelope, fileKey []byte) (cipher.Stream, error) {
-	keySize, mode, err := parseCipher(env.Cipher)
+	keySize, mode, err := binlogserver.ParseCipher(env.Cipher)
 	if err != nil {
 		return nil, err
 	}
@@ -190,24 +201,4 @@ func dataStream(env *binlogserver.FileDataEnvelope, fileKey []byte) (cipher.Stre
 	}
 
 	return cipher.NewCTR(block, iv), nil
-}
-
-func parseCipher(name string) (keySize int, mode string, err error) {
-	parts := strings.Split(strings.ToUpper(strings.TrimSpace(name)), "-")
-	if len(parts) != 3 || parts[0] != "AES" {
-		return 0, "", fmt.Errorf("unsupported cipher %q, expected AES-<128|192|256>-<mode>", name)
-	}
-
-	switch parts[1] {
-	case "128":
-		keySize = 16
-	case "192":
-		keySize = 24
-	case "256":
-		keySize = 32
-	default:
-		return 0, "", fmt.Errorf("unsupported AES key size in cipher %q", name)
-	}
-
-	return keySize, parts[2], nil
 }

--- a/cmd/pitr/decrypt_test.go
+++ b/cmd/pitr/decrypt_test.go
@@ -29,6 +29,9 @@ func TestDecryptingReader(t *testing.T) {
 		{desc: "AES-128-CBC", kekCipher: "AES-128-CBC"},
 		{desc: "AES-192-CBC", kekCipher: "AES-192-CBC"},
 		{desc: "AES-256-CBC", kekCipher: "AES-256-CBC"},
+		{desc: "AES-128-CTR", kekCipher: "AES-128-CTR"},
+		{desc: "AES-192-CTR", kekCipher: "AES-192-CTR"},
+		{desc: "AES-256-CTR", kekCipher: "AES-256-CTR"},
 		{desc: "AES-128-GCM", kekCipher: "AES-128-GCM"},
 		{desc: "AES-192-GCM", kekCipher: "AES-192-GCM"},
 		{desc: "AES-256-GCM", kekCipher: "AES-256-GCM"},
@@ -88,7 +91,7 @@ func TestDecryptingReader(t *testing.T) {
 func encryptBinlogForTest(t *testing.T, plaintext []byte, kekCipher string) ([]byte, binlogserver.BinlogEntry, *binlogserver.Keyring) {
 	t.Helper()
 
-	keySize, mode, err := parseCipher(kekCipher)
+	keySize, mode, err := binlogserver.ParseCipher(kekCipher)
 	require.NoError(t, err)
 
 	kek := bytes.Repeat([]byte{0x11}, keySize)
@@ -148,6 +151,15 @@ func wrapFileKeyForTest(t *testing.T, kek []byte, mode string, fileKey []byte) *
 		iv := bytes.Repeat([]byte{0x44}, block.BlockSize())
 		wrapped := make([]byte, len(fileKey))
 		cipher.NewCBCEncrypter(block, iv).CryptBlocks(wrapped, fileKey)
+		return &binlogserver.FileKeyEnvelope{
+			DataHex: hex.EncodeToString(wrapped),
+			IVHex:   hex.EncodeToString(iv),
+		}
+
+	case "CTR":
+		iv := bytes.Repeat([]byte{0x44}, block.BlockSize())
+		wrapped := make([]byte, len(fileKey))
+		cipher.NewCTR(block, iv).XORKeyStream(wrapped, fileKey)
 		return &binlogserver.FileKeyEnvelope{
 			DataHex: hex.EncodeToString(wrapped),
 			IVHex:   hex.EncodeToString(iv),

--- a/pkg/binlogserver/config.go
+++ b/pkg/binlogserver/config.go
@@ -210,6 +210,8 @@ func getKeyringAndEncryptionConfig(
 	kekID := spec.Storage.Encryption.KekID
 	if kekID == "" {
 		kekID = keyring.Keys[0].Id
+	} else if keyring.FindKey(kekID) == nil {
+		return nil, nil, errors.Errorf("keyring secret %q does not contain a key with ID %q", sel.Name, kekID)
 	}
 
 	return keyringCfg, &EncryptionConfig{
@@ -243,6 +245,7 @@ func getAndCheckKeyringSecret(
 	if err := keyring.Validate(); err != nil {
 		return nil, errors.Wrap(err, "validate keyring")
 	}
+
 	return &keyring, nil
 }
 

--- a/pkg/binlogserver/config_test.go
+++ b/pkg/binlogserver/config_test.go
@@ -125,6 +125,30 @@ func TestGetConfigurationEncryptionValidation(t *testing.T) {
 			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[]}`)},
 			expectedError: "keyring must contain at least one key",
 		},
+		"empty key ID": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"","cipher":"AES-256-CBC","data_hex":"00"}]}`)},
+			expectedError: "keyring contains a key with empty ID",
+		},
+		"empty cipher": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"alpha","cipher":"","data_hex":"00"}]}`)},
+			expectedError: "keyring contains a key with empty cipher",
+		},
+		"malformed cipher": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"alpha","cipher":"AES-256","data_hex":"00"}]}`)},
+			expectedError: `keyring key "alpha": unsupported cipher "AES-256", expected AES-<128|192|256>-<mode>`,
+		},
+		"unsupported key size": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"alpha","cipher":"AES-512-CBC","data_hex":"00"}]}`)},
+			expectedError: `keyring key "alpha": unsupported AES key size in cipher "AES-512-CBC"`,
+		},
+		"unsupported KEK cipher mode": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"alpha","cipher":"AES-256-OFB","data_hex":"00"}]}`)},
+			expectedError: `keyring key "alpha": unsupported KEK cipher mode "OFB", supported modes are ECB, CBC, CTR, GCM`,
+		},
+		"second key is invalid": {
+			keyringData:   map[string][]byte{"keyring.json": []byte(`{"version":1,"keys":[{"id":"alpha","cipher":"AES-256-CBC","data_hex":"00"},{"id":"beta","cipher":"AES-256-XTS","data_hex":"00"}]}`)},
+			expectedError: `keyring key "beta": unsupported KEK cipher mode "XTS"`,
+		},
 	}
 
 	for name, tt := range tests {

--- a/pkg/binlogserver/keyring.go
+++ b/pkg/binlogserver/keyring.go
@@ -1,6 +1,13 @@
 package binlogserver
 
-import "github.com/pkg/errors"
+import (
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var kekCipherModes = []string{"ECB", "CBC", "CTR", "GCM"}
 
 type Keyring struct {
 	Version int   `json:"version"`
@@ -26,5 +33,44 @@ func (k Keyring) Validate() error {
 	if len(k.Keys) == 0 {
 		return errors.New("keyring must contain at least one key")
 	}
+
+	for _, key := range k.Keys {
+		if key.Id == "" {
+			return errors.New("keyring contains a key with empty ID")
+		}
+		if key.Cipher == "" {
+			return errors.New("keyring contains a key with empty cipher")
+		}
+
+		_, mode, err := ParseCipher(key.Cipher)
+		if err != nil {
+			return errors.Wrapf(err, "keyring key %q", key.Id)
+		}
+		if !slices.Contains(kekCipherModes, mode) {
+			return errors.Errorf("keyring key %q: unsupported KEK cipher mode %q, supported modes are %s",
+				key.Id, mode, strings.Join(kekCipherModes, ", "))
+		}
+	}
+
 	return nil
+}
+
+func ParseCipher(name string) (keySize int, mode string, err error) {
+	parts := strings.Split(strings.ToUpper(strings.TrimSpace(name)), "-")
+	if len(parts) != 3 || parts[0] != "AES" {
+		return 0, "", errors.Errorf("unsupported cipher %q, expected AES-<128|192|256>-<mode>", name)
+	}
+
+	switch parts[1] {
+	case "128":
+		keySize = 16
+	case "192":
+		keySize = 24
+	case "256":
+		keySize = 32
+	default:
+		return 0, "", errors.Errorf("unsupported AES key size in cipher %q", name)
+	}
+
+	return keySize, parts[2], nil
 }

--- a/pkg/binlogserver/keyring_test.go
+++ b/pkg/binlogserver/keyring_test.go
@@ -1,0 +1,98 @@
+package binlogserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCipher(t *testing.T) {
+	testCases := []struct {
+		name        string
+		wantKeySize int
+		wantMode    string
+		wantErr     bool
+	}{
+		{"AES-128-ECB", 16, "ECB", false},
+		{"AES-192-CBC", 24, "CBC", false},
+		{"AES-256-GCM", 32, "GCM", false},
+		{"AES-256-CTR", 32, "CTR", false},
+		{"AES-256-XTS", 32, "XTS", false},
+		{"aes-128-ecb", 16, "ECB", false},
+		{" AES-192-CBC ", 24, "CBC", false},
+		{"DES-128-CBC", 0, "", true},
+		{"AES-128", 0, "", true},
+		{"xx", 0, "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotKeySize, gotMode, err := ParseCipher(tc.name)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantKeySize, gotKeySize)
+				require.Equal(t, tc.wantMode, gotMode)
+			}
+		})
+	}
+}
+
+func TestValidateKeyring(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		keyring Keyring
+		wantErr string
+	}{
+		{
+			desc:    "no keys",
+			keyring: Keyring{Version: 1, Keys: []Key{}},
+			wantErr: "keyring must contain at least one key",
+		},
+
+		{
+			desc: "key with no ID",
+			keyring: Keyring{
+				Version: 1,
+				Keys: []Key{
+					{Id: "", Cipher: "AES-256-CBC", DataHex: "00"},
+				},
+			},
+			wantErr: "keyring contains a key with empty ID",
+		},
+
+		{
+			desc: "key with no cipher",
+			keyring: Keyring{
+				Version: 1,
+				Keys: []Key{
+					{Id: "alpha", Cipher: "", DataHex: "00"},
+				},
+			},
+			wantErr: "keyring contains a key with empty cipher",
+		},
+
+		{
+			desc: "unsupported cipher",
+			keyring: Keyring{
+				Version: 1,
+				Keys: []Key{
+					{Id: "alpha", Cipher: "AES-256-xyz", DataHex: "00"},
+				},
+			},
+			wantErr: "unsupported KEK cipher mode",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.keyring.Validate()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

Adds additional validation to the keyring secret. Also parses `CTR` cipher mode for KEK, which was previously left out

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
