### PR TITLE
K8SPS-849 fix pitr panic on unusable keyring file

### DIFF
--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -136,9 +136,11 @@ func run(ctx context.Context, newS3 newStorageFn, newDB newDatabaseFn, getSecret
 		if err != nil {
 			return fmt.Errorf("read keyring file: %w", err)
 		}
-		if err := json.Unmarshal(keyringData, &keyring); err != nil {
-			return fmt.Errorf("parse keyring json: %w", err)
+		kr, err := binlogserver.DecodeKeyring(keyringData)
+		if err != nil {
+			return fmt.Errorf("parse keyring %s: %w", keyringPath, err)
 		}
+		keyring = &kr
 		log.Printf("loaded %d keys from keyring", len(keyring.Keys))
 	}
 

--- a/cmd/pitr/main_test.go
+++ b/cmd/pitr/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -90,20 +91,22 @@ func TestRun(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		entries       []binlogserver.BinlogEntry
-		rawContent    string
-		pitrType      string
-		pitrGTID      string
-		pitrDate      string
-		pitrForce     string
-		db            *fakeDB
-		newDB         func(ctx context.Context, params db.DBParams) (Database, error)
-		newS3         func(*fakeStorage) newStorageFn
-		getSecret     func(apiv1.SystemUser) (string, error)
-		applyErr      error
-		expectedError string
-		checkApply    func(t *testing.T, call applyCall)
-		checkObjects  func(t *testing.T, objects []binlogSource)
+		entries        []binlogserver.BinlogEntry
+		rawContent     string
+		keyringContent string
+		pitrType       string
+		pitrGTID       string
+		pitrDate       string
+		pitrForce      string
+		db             *fakeDB
+		newDB          func(ctx context.Context, params db.DBParams) (Database, error)
+		newS3          func(*fakeStorage) newStorageFn
+		getSecret      func(apiv1.SystemUser) (string, error)
+		applyErr       error
+		expectedError  string
+		checkApply     func(t *testing.T, call applyCall)
+		checkObjects   func(t *testing.T, objects []binlogSource)
+		keyringPath    func(t *testing.T) string
 	}{
 		"missing BINLOGS_PATH": {
 			expectedError: "BINLOGS_PATH",
@@ -267,6 +270,71 @@ func TestRun(t *testing.T) {
 				assert.Equal(t, "plain binlog", string(data))
 			},
 		},
+		"keyring file with JSON null": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: "null",
+			expectedError:  "keyring must contain at least one key",
+		},
+		"keyring file with empty JSON object": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: "{}",
+			expectedError:  "keyring must contain at least one key",
+		},
+		"keyring file with empty key list": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: `{"version":1,"keys":[]}`,
+			expectedError:  "keyring must contain at least one key",
+		},
+		"keyring file with invalid JSON": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: "not-json",
+			expectedError:  "parse keyring",
+		},
+		"keyring file with unsupported cipher": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: `{"version":1,"keys":[{"id":"k1","cipher":"AES-256-XTS","data_hex":"00"}]}`,
+			expectedError:  "unsupported KEK cipher mode",
+		},
+		"keyring file with a key missing an ID": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: `{"version":1,"keys":[{"cipher":"AES-256-CBC","data_hex":"00"}]}`,
+			expectedError:  "empty ID",
+		},
+		"valid keyring file is loaded": {
+			entries:        defaultEntries,
+			pitrType:       "gtid",
+			pitrGTID:       "uuid:1",
+			db:             &fakeDB{},
+			keyringContent: `{"version":1,"keys":[{"id":"k1","cipher":"AES-256-CBC","data_hex":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"}]}`,
+		},
+		"missing keyring file": {
+			entries:  defaultEntries,
+			pitrType: "gtid",
+			pitrGTID: "uuid:1",
+			db:       &fakeDB{},
+			keyringPath: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "does-not-exist.json")
+			},
+			expectedError: "read keyring file",
+		},
 	}
 
 	for name, tc := range tests {
@@ -294,7 +362,15 @@ func TestRun(t *testing.T) {
 			t.Setenv("PITR_DATE", tc.pitrDate)
 			t.Setenv("PITR_FORCE", tc.pitrForce)
 			t.Setenv("S3_BUCKET", bucket)
-			t.Setenv("KEYRING_PATH", "")
+			keyringPath := ""
+			switch {
+			case tc.keyringPath != nil:
+				keyringPath = tc.keyringPath(t)
+			case tc.keyringContent != "":
+				keyringPath = filepath.Join(t.TempDir(), "keyring.json")
+				require.NoError(t, os.WriteFile(keyringPath, []byte(tc.keyringContent), 0o600))
+			}
+			t.Setenv("KEYRING_PATH", keyringPath)
 
 			fakeDatabase := tc.db
 

--- a/pkg/binlogserver/config.go
+++ b/pkg/binlogserver/config.go
@@ -237,13 +237,9 @@ func getAndCheckKeyringSecret(
 		return nil, errors.Errorf("key %q not found in keyring secret %q", secretKey, secretName)
 	}
 
-	keyring, err := decodeKeyringStrict(data)
+	keyring, err := DecodeKeyring(data)
 	if err != nil {
 		return nil, errors.Wrap(err, "decode keyring")
-	}
-
-	if err := keyring.Validate(); err != nil {
-		return nil, errors.Wrap(err, "validate keyring")
 	}
 
 	return &keyring, nil

--- a/pkg/binlogserver/keyring.go
+++ b/pkg/binlogserver/keyring.go
@@ -20,6 +20,22 @@ type Key struct {
 	DataHex string `json:"data_hex"`
 }
 
+// DecodeKeyring parses keyring JSON and validates its contents. It rejects
+// input that decodes without error but yields an unusable keyring, e.g. the
+// JSON literal "null" or an object with no keys.
+func DecodeKeyring(data []byte) (Keyring, error) {
+	keyring, err := decodeKeyringStrict(data)
+	if err != nil {
+		return Keyring{}, err
+	}
+
+	if err := keyring.Validate(); err != nil {
+		return Keyring{}, errors.Wrap(err, "validate keyring")
+	}
+
+	return keyring, nil
+}
+
 func (k Keyring) FindKey(id string) *Key {
 	for i, key := range k.Keys {
 		if key.Id == id {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
The restore pod unmarshalled the keyring file into a *Keyring. A keyring secret containing the JSON literal "null" decodes into that pointer without error and leaves it nil, so the nil check passed and the next line dereferenced it:
    log.Printf("loaded %d keys from keyring", len(keyring.Keys))
That crashed the pitr container with a SIGSEGV before any binlog was touched.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
