### PR TITLE
K8SPS-848: liveness check should tolerate only RECOVERING state

### DIFF
--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -239,10 +239,8 @@ func checkLivenessGR(ctx context.Context) error {
 		return errors.Wrap(err, "get group replication state")
 	}
 
-	// A member can enter error state either while applying transactions or during the recovery phase.
-	// Readiness probe will fail in error state.
-	if state == mysqldb.MemberStateRecovering || state == mysqldb.MemberStateError {
-		log.Printf("member in %s state, not killing", state)
+	if state == mysqldb.MemberStateRecovering {
+		log.Println("member is recovering, not killing")
 		return nil
 	}
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Full cluster crash recovery may be stuck for ~15mins if a pod goes into ERROR state

**Cause:**
https://github.com/percona/percona-server-mysql-operator/pull/1465 add a check such that liveness tolerates ERROR state as sometimes this may be expected when joining the cluster.

**Solution:**
Do not tolerate ERROR state, only RECOVERING

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
