### PR TITLE
K8SPS-859 fix PVC autoscale loop after scaling replicas

### DIFF
--- a/e2e-tests/tests/pvc-resize/01-create-cluster.yaml
+++ b/e2e-tests/tests/pvc-resize/01-create-cluster.yaml
@@ -12,6 +12,7 @@ commands:
 
       cr="$(get_cr \
           | yq eval '.spec.mysql.clusterType="group-replication"' - \
+          | yq eval '.spec.unsafeFlags.mysqlSize=true' - \
           | yq eval '.spec.mysql.size=3' - \
           | yq eval '.spec.proxy.router.enabled=false' - \
           | yq eval '.spec.proxy.haproxy.enabled=true' - \

--- a/e2e-tests/tests/pvc-resize/01-create-cluster.yaml
+++ b/e2e-tests/tests/pvc-resize/01-create-cluster.yaml
@@ -12,8 +12,8 @@ commands:
 
       cr="$(get_cr \
           | yq eval '.spec.mysql.clusterType="group-replication"' - \
-          | yq eval '.spec.unsafeFlags.mysqlSize=true' - \
           | yq eval '.spec.mysql.size=3' - \
+          | yq eval '.spec.mysql.affinity.antiAffinityTopologyKey="none"' - \
           | yq eval '.spec.proxy.router.enabled=false' - \
           | yq eval '.spec.proxy.haproxy.enabled=true' - \
           | yq eval '.spec.enableVolumeExpansion=true' - \

--- a/e2e-tests/tests/pvc-resize/06-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/06-assert.yaml
@@ -1,14 +1,14 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 420
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pvc-resize-mysql
 status:
-  replicas: 1
-  readyReplicas: 1
+  replicas: 5
+  readyReplicas: 5
 ---
 apiVersion: ps.percona.com/v1
 kind: PerconaServerMySQL
@@ -16,6 +16,25 @@ metadata:
   name: pvc-resize
 status:
   mysql:
-    ready: 1
-    size: 1
+    ready: 5
+    size: 5
   state: ready
+---
+# the two new replicas got their claims at the size in the template
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-3
+status:
+  phase: Bound
+  capacity:
+    storage: 3Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-4
+status:
+  phase: Bound
+  capacity:
+    storage: 3Gi

--- a/e2e-tests/tests/pvc-resize/06-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/06-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 420
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pvc-resize-mysql
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+status:
+  mysql:
+    ready: 1
+    size: 1
+  state: ready

--- a/e2e-tests/tests/pvc-resize/06-scale-down.yaml
+++ b/e2e-tests/tests/pvc-resize/06-scale-down.yaml
@@ -1,0 +1,9 @@
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+spec:
+  mysql:
+    size: 1

--- a/e2e-tests/tests/pvc-resize/06-scale-up.yaml
+++ b/e2e-tests/tests/pvc-resize/06-scale-up.yaml
@@ -6,4 +6,4 @@ metadata:
     - percona.com/delete-mysql-pods-in-order
 spec:
   mysql:
-    size: 1
+    size: 5

--- a/e2e-tests/tests/pvc-resize/07-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/07-assert.yaml
@@ -1,13 +1,31 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 60
+timeout: 420
 ---
-# scaling down does not delete the PVCs of the removed replicas: they are left
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pvc-resize-mysql
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+status:
+  mysql:
+    ready: 3
+    size: 3
+  state: ready
+---
+# scaling down does not delete the claims of the removed replicas: they are left
 # behind at the old size and are the reason a later resize used to loop
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: datadir-pvc-resize-mysql-1
+  name: datadir-pvc-resize-mysql-3
 status:
   phase: Bound
   capacity:
@@ -16,7 +34,7 @@ status:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: datadir-pvc-resize-mysql-2
+  name: datadir-pvc-resize-mysql-4
 status:
   phase: Bound
   capacity:

--- a/e2e-tests/tests/pvc-resize/07-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/07-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+# scaling down does not delete the PVCs of the removed replicas: they are left
+# behind at the old size and are the reason a later resize used to loop
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-1
+status:
+  phase: Bound
+  capacity:
+    storage: 3Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-2
+status:
+  phase: Bound
+  capacity:
+    storage: 3Gi

--- a/e2e-tests/tests/pvc-resize/07-scale-down.yaml
+++ b/e2e-tests/tests/pvc-resize/07-scale-down.yaml
@@ -1,0 +1,9 @@
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+  finalizers:
+    - percona.com/delete-mysql-pods-in-order
+spec:
+  mysql:
+    size: 3

--- a/e2e-tests/tests/pvc-resize/08-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/08-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 420
 ---
 apiVersion: ps.percona.com/v1
 kind: PerconaServerMySQL
@@ -8,8 +8,8 @@ metadata:
   name: pvc-resize
 status:
   mysql:
-    ready: 1
-    size: 1
+    ready: 3
+    size: 3
   state: ready
 ---
 apiVersion: v1
@@ -40,5 +40,5 @@ spec:
           storage: 4Gi
       volumeMode: Filesystem
 status:
-  replicas: 1
-  readyReplicas: 1
+  replicas: 3
+  readyReplicas: 3

--- a/e2e-tests/tests/pvc-resize/08-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/08-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+status:
+  mysql:
+    ready: 1
+    size: 1
+  state: ready
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-0
+status:
+  capacity:
+    storage: 4Gi
+---
+# the volume claim template was stale, so it is expected to be updated here,
+# which the operator can only do by recreating the statefulset
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pvc-resize-mysql
+spec:
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: datadir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 4Gi
+      volumeMode: Filesystem
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/e2e-tests/tests/pvc-resize/08-resize-with-leftovers.yaml
+++ b/e2e-tests/tests/pvc-resize/08-resize-with-leftovers.yaml
@@ -8,9 +8,9 @@ commands:
 
       source ../../functions
 
-      # The PVCs left behind by the scale down are smaller than the requested
-      # size and have no pod, so they can never be resized. They must not be
-      # taken into account when the operator decides whether a resize is needed.
+      # The claims left behind by the scale down are smaller than the requested
+      # size and have no pod, so they can never report the new size themselves.
+      # They must not keep the operator asking for the resize over and over.
       kubectl -n "${NAMESPACE}" patch ps pvc-resize \
           --type=merge \
           -p='{"spec":{"mysql":{"volumeSpec":{"persistentVolumeClaim":{"resources":{"requests":{"storage":"4Gi"}}}}}}}'

--- a/e2e-tests/tests/pvc-resize/08-resize-with-leftovers.yaml
+++ b/e2e-tests/tests/pvc-resize/08-resize-with-leftovers.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      # The PVCs left behind by the scale down are smaller than the requested
+      # size and have no pod, so they can never be resized. They must not be
+      # taken into account when the operator decides whether a resize is needed.
+      kubectl -n "${NAMESPACE}" patch ps pvc-resize \
+          --type=merge \
+          -p='{"spec":{"mysql":{"volumeSpec":{"persistentVolumeClaim":{"resources":{"requests":{"storage":"4Gi"}}}}}}}'

--- a/e2e-tests/tests/pvc-resize/09-verify-no-resize-loop.yaml
+++ b/e2e-tests/tests/pvc-resize/09-verify-no-resize-loop.yaml
@@ -10,8 +10,8 @@ commands:
 
       cluster_name="$(get_cluster_name)"
 
-      # The leftover PVCs stay at the old size on purpose: nothing mounts them.
-      for i in 1 2; do
+      # the claims of the removed replicas stay at the old size on purpose
+      for i in 3 4; do
           size=$(kubectl -n "${NAMESPACE}" get pvc "datadir-${cluster_name}-mysql-${i}" -o jsonpath='{.status.capacity.storage}')
           if [[ ${size} != "3Gi" ]]; then
               echo "ERROR: leftover PVC datadir-${cluster_name}-mysql-${i} is ${size}, expected it to stay 3Gi"
@@ -19,8 +19,6 @@ commands:
           fi
       done
 
-      # The resize is finished, so it must not be running any more. A statefulset
-      # that keeps being recreated is the signature of the loop this guards.
       uid_before=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
       generation_before=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.generation}')
 
@@ -35,14 +33,9 @@ commands:
           fi
 
           uid_now=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
-          if [[ ${uid_now} != "${uid_before}" ]]; then
-              echo "ERROR: statefulset was recreated (${uid_before} -> ${uid_now})"
-              exit 1
-          fi
-
           generation_now=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.generation}')
-          if [[ ${generation_now} != "${generation_before}" ]]; then
-              echo "ERROR: statefulset keeps changing (generation ${generation_before} -> ${generation_now})"
+          if [[ ${uid_now} != "${uid_before}" || ${generation_now} != "${generation_before}" ]]; then
+              echo "ERROR: statefulset keeps being changed (${uid_before}/${generation_before} -> ${uid_now}/${generation_now})"
               exit 1
           fi
       done

--- a/e2e-tests/tests/pvc-resize/09-verify-no-resize-loop.yaml
+++ b/e2e-tests/tests/pvc-resize/09-verify-no-resize-loop.yaml
@@ -1,0 +1,50 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - timeout: 240
+    script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      cluster_name="$(get_cluster_name)"
+
+      # The leftover PVCs stay at the old size on purpose: nothing mounts them.
+      for i in 1 2; do
+          size=$(kubectl -n "${NAMESPACE}" get pvc "datadir-${cluster_name}-mysql-${i}" -o jsonpath='{.status.capacity.storage}')
+          if [[ ${size} != "3Gi" ]]; then
+              echo "ERROR: leftover PVC datadir-${cluster_name}-mysql-${i} is ${size}, expected it to stay 3Gi"
+              exit 1
+          fi
+      done
+
+      # The resize is finished, so it must not be running any more. A statefulset
+      # that keeps being recreated is the signature of the loop this guards.
+      uid_before=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
+      generation_before=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.generation}')
+
+      for i in {1..12}; do
+          sleep 10
+
+          annotation=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" \
+              -o jsonpath='{.metadata.annotations.percona\.com/pvc-resize-in-progress}')
+          if [[ -n ${annotation} ]]; then
+              echo "ERROR: a resize is still in progress (${annotation}) after it completed"
+              exit 1
+          fi
+
+          uid_now=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
+          if [[ ${uid_now} != "${uid_before}" ]]; then
+              echo "ERROR: statefulset was recreated (${uid_before} -> ${uid_now})"
+              exit 1
+          fi
+
+          generation_now=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.generation}')
+          if [[ ${generation_now} != "${generation_before}" ]]; then
+              echo "ERROR: statefulset keeps changing (generation ${generation_before} -> ${generation_now})"
+              exit 1
+          fi
+      done
+
+      echo "no resize loop: statefulset stable and no resize in progress"

--- a/e2e-tests/tests/pvc-resize/10-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/10-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pvc-resize-mysql
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+status:
+  mysql:
+    ready: 3
+    size: 3
+  state: ready
+---
+# the leftovers were expanded, so a returning replica no longer starts on a
+# volume that is too small for the data it has to recover
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-1
+status:
+  capacity:
+    storage: 4Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-pvc-resize-mysql-2
+status:
+  capacity:
+    storage: 4Gi

--- a/e2e-tests/tests/pvc-resize/10-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/10-assert.yaml
@@ -1,14 +1,14 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 120
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pvc-resize-mysql
 status:
-  replicas: 3
-  readyReplicas: 3
+  replicas: 5
+  readyReplicas: 5
 ---
 apiVersion: ps.percona.com/v1
 kind: PerconaServerMySQL
@@ -16,16 +16,14 @@ metadata:
   name: pvc-resize
 status:
   mysql:
-    ready: 3
-    size: 3
+    ready: 5
+    size: 5
   state: ready
 ---
-# the leftovers were expanded, so a returning replica no longer starts on a
-# volume that is too small for the data it has to recover
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: datadir-pvc-resize-mysql-1
+  name: datadir-pvc-resize-mysql-3
 status:
   capacity:
     storage: 4Gi
@@ -33,7 +31,7 @@ status:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: datadir-pvc-resize-mysql-2
+  name: datadir-pvc-resize-mysql-4
 status:
   capacity:
     storage: 4Gi

--- a/e2e-tests/tests/pvc-resize/10-scale-up.yaml
+++ b/e2e-tests/tests/pvc-resize/10-scale-up.yaml
@@ -1,0 +1,48 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - timeout: 600
+    script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      cluster_name="$(get_cluster_name)"
+
+      uid_before=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
+      echo "statefulset uid before scaling up: ${uid_before}"
+
+      kubectl -n "${NAMESPACE}" patch ps "${cluster_name}" \
+          --type=merge \
+          -p='{"spec":{"mysql":{"size":3}}}'
+
+      for i in {1..60}; do
+          ready=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.mysql.ready}')
+          state=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.state}')
+          echo "attempt ${i}/60: ready=${ready} state=${state}"
+          if [[ ${ready} == "3" && ${state} == "ready" ]]; then
+              break
+          fi
+          sleep 10
+      done
+
+      ready=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.mysql.ready}')
+      if [[ ${ready} != "3" ]]; then
+          echo "ERROR: only ${ready}/3 replicas came back. A replica whose leftover PVC was never"
+          echo "       expanded cannot recover, and an unmounted PVC that never reports its resize"
+          echo "       status keeps the resize in progress, which holds the scale up back."
+          kubectl -n "${NAMESPACE}" get pvc -o custom-columns=NAME:.metadata.name,CAP:.status.capacity.storage,REQ:.spec.resources.requests.storage,STATUS:.status.allocatedResourceStatuses
+          kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.metadata.annotations}'
+          exit 1
+      fi
+
+      uid_after=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
+      if [[ ${uid_after} != "${uid_before}" ]]; then
+          echo "ERROR: statefulset was recreated while scaling up (${uid_before} -> ${uid_after})."
+          echo "       Its volume claim template already asked for the requested size, so recreating"
+          echo "       it only restarts the replicas for nothing."
+          exit 1
+      fi
+
+      echo "leftover PVCs expanded and replicas back without recreating the statefulset"

--- a/e2e-tests/tests/pvc-resize/10-scale-up.yaml
+++ b/e2e-tests/tests/pvc-resize/10-scale-up.yaml
@@ -1,7 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 600
+  - timeout: 900
     script: |-
       set -o errexit
       set -o xtrace
@@ -15,27 +15,64 @@ commands:
 
       kubectl -n "${NAMESPACE}" patch ps "${cluster_name}" \
           --type=merge \
-          -p='{"spec":{"mysql":{"size":3}}}'
+          -p='{"spec":{"mysql":{"size":5}}}'
 
-      for i in {1..60}; do
+      for i in {1..80}; do
           ready=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.mysql.ready}')
           state=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.state}')
-          echo "attempt ${i}/60: ready=${ready} state=${state}"
-          if [[ ${ready} == "3" && ${state} == "ready" ]]; then
+          echo "attempt ${i}/80: ready=${ready} state=${state}"
+          if [[ ${ready} == "5" && ${state} == "ready" ]]; then
               break
           fi
           sleep 10
       done
 
       ready=$(kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.status.mysql.ready}')
-      if [[ ${ready} != "3" ]]; then
-          echo "ERROR: only ${ready}/3 replicas came back. A replica whose leftover PVC was never"
-          echo "       expanded cannot recover, and an unmounted PVC that never reports its resize"
-          echo "       status keeps the resize in progress, which holds the scale up back."
-          kubectl -n "${NAMESPACE}" get pvc -o custom-columns=NAME:.metadata.name,CAP:.status.capacity.storage,REQ:.spec.resources.requests.storage,STATUS:.status.allocatedResourceStatuses
+      if [[ ${ready} != "5" ]]; then
+          echo "ERROR: only ${ready}/5 replicas came back. A replica whose leftover claim was never"
+          echo "       expanded cannot recover, and a claim that never reports the new size keeps the"
+          echo "       resize in progress, which holds the scale up back."
+          kubectl -n "${NAMESPACE}" get pvc -o custom-columns=NAME:.metadata.name,CAP:.status.capacity.storage,REQ:.spec.resources.requests.storage,STATUS:.status.allocatedResourceStatuses,COND:.status.conditions[*].type
           kubectl -n "${NAMESPACE}" get ps "${cluster_name}" -o jsonpath='{.metadata.annotations}'
           exit 1
       fi
+
+      # the leftovers had to be expanded before their replica could recover
+      for i in 3 4; do
+          size=$(kubectl -n "${NAMESPACE}" get pvc "datadir-${cluster_name}-mysql-${i}" -o jsonpath='{.status.capacity.storage}')
+          if [[ ${size} != "4Gi" ]]; then
+              echo "ERROR: reused claim datadir-${cluster_name}-mysql-${i} is ${size}, expected 4Gi"
+              exit 1
+          fi
+      done
+
+      # The point of the fix: the volume has to be expanded before the replica
+      # exists, or it starts cloning onto a volume that is too small. Both
+      # timestamps are RFC3339 in UTC, so they compare as strings.
+      for i in 3 4; do
+          pod_created=$(kubectl -n "${NAMESPACE}" get pod "${cluster_name}-mysql-${i}" -o jsonpath='{.metadata.creationTimestamp}')
+          expanded_at=$(kubectl -n "${NAMESPACE}" get events.events.k8s.io \
+              --field-selector "regarding.name=datadir-${cluster_name}-mysql-${i}" -o json \
+              | jq -r '[.items[]
+                        | select(.reason == "ExternalExpanding" or .reason == "Resizing" or .reason == "FileSystemResizeRequired")
+                        | (.deprecatedFirstTimestamp // .eventTime)]
+                       | sort | first // empty')
+
+          if [[ -z ${expanded_at} ]]; then
+              echo "ERROR: no expansion was ever recorded for datadir-${cluster_name}-mysql-${i},"
+              echo "       so there is nothing to show it was expanded before its replica started"
+              kubectl -n "${NAMESPACE}" get events.events.k8s.io --field-selector "regarding.name=datadir-${cluster_name}-mysql-${i}"
+              exit 1
+          fi
+
+          echo "claim ${i}: expansion started ${expanded_at}, replica created ${pod_created}"
+          if [[ ${expanded_at} > ${pod_created} ]]; then
+              echo "ERROR: datadir-${cluster_name}-mysql-${i} was expanded at ${expanded_at}, after its"
+              echo "       replica was created at ${pod_created}. The replica started cloning onto a"
+              echo "       volume that was still too small."
+              exit 1
+          fi
+      done
 
       uid_after=$(kubectl -n "${NAMESPACE}" get sts "${cluster_name}-mysql" -o jsonpath='{.metadata.uid}')
       if [[ ${uid_after} != "${uid_before}" ]]; then
@@ -45,4 +82,4 @@ commands:
           exit 1
       fi
 
-      echo "leftover PVCs expanded and replicas back without recreating the statefulset"
+      echo "leftover claims expanded and all replicas back without recreating the statefulset"

--- a/e2e-tests/tests/pvc-resize/11-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/11-assert.yaml
@@ -8,5 +8,5 @@ metadata:
   name: pvc-resize
 status:
   mysql:
-    ready: 3
+    ready: 5
   state: ready

--- a/e2e-tests/tests/pvc-resize/11-assert.yaml
+++ b/e2e-tests/tests/pvc-resize/11-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: ps.percona.com/v1
+kind: PerconaServerMySQL
+metadata:
+  name: pvc-resize
+status:
+  mysql:
+    ready: 3
+  state: ready

--- a/e2e-tests/tests/pvc-resize/11-verify-data.yaml
+++ b/e2e-tests/tests/pvc-resize/11-verify-data.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      # every replica came back on an expanded volume with the data intact
+      original_count=$(kubectl get configmap -n "${NAMESPACE}" initial-data-count -o jsonpath='{.data.count}')
+      current_count=$(run_mysql "SELECT COUNT(*) FROM pvctest.data" "-h $(get_haproxy_svc $(get_cluster_name))")
+
+      # 05-verify-data inserted one extra row
+      expected_count=$((original_count + 1))
+      if [[ ${current_count} != "${expected_count}" ]]; then
+          echo "ERROR: data count mismatch after scaling back up. expected ${expected_count}, got ${current_count}"
+          exit 1
+      fi
+
+      echo "data intact on a cluster whose replicas returned to expanded volumes"

--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -2341,3 +2341,284 @@ var _ = Describe("BinlogServer", Ordered, func() {
 		Expect(sts.Spec.Replicas).To(gs.PointTo(BeEquivalentTo(1)))
 	})
 })
+
+var _ = Describe("PVC Resizing with orphaned PVCs", Ordered, func() {
+	ctx := context.Background()
+
+	const crName = "pvc-resize-orphan"
+	const ns = crName
+	crNamespacedName := types.NamespacedName{Name: crName, Namespace: ns}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ns,
+			Namespace: ns,
+		},
+	}
+
+	BeforeAll(func() {
+		Expect(k8sClient.Create(ctx, namespace)).To(Not(HaveOccurred()))
+	})
+
+	AfterAll(func() {
+		_ = k8sClient.Delete(ctx, namespace)
+	})
+
+	// Scaling the cluster up and back down leaves the PVCs of the removed
+	// replicas behind, still holding the old size. They have no pod, so they are
+	// never resized and must not be taken into account when the operator decides
+	// whether a resize is needed.
+	Context("PVCs left behind by a scale down are smaller than the live ones", Ordered, func() {
+		cr, err := readDefaultCR(crName, ns)
+
+		It("should read default cr.yaml", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		cr.Spec.VolumeExpansionEnabled = true
+		orphanSize := resource.MustParse("2Gi")
+		liveSize := resource.MustParse("3Gi")
+		cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = liveSize
+
+		It("should create PerconaServerMySQL", func() {
+			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
+		})
+
+		It("should reconcile to create StatefulSet", func() {
+			_, err := reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		sts := &appsv1.StatefulSet{}
+		stsName := types.NamespacedName{Name: cr.Name + "-mysql", Namespace: ns}
+		It("should create MySQL StatefulSet", func() {
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, stsName, sts) == nil
+			}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+		})
+
+		It("should create StorageClass that supports volume expansion", func() {
+			allowVolumeExpansion := true
+			sc := &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "orphan-storage-class",
+				},
+				Provisioner:          "kubernetes.io/no-provisioner",
+				AllowVolumeExpansion: &allowVolumeExpansion,
+			}
+			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+		})
+
+		It("should create 5 PVCs where the 2 orphaned ones kept the old size", func() {
+			exposer := mysql.Exposer(*cr)
+			var claim *corev1.PersistentVolumeClaim
+			for _, c := range sts.Spec.VolumeClaimTemplates {
+				if c.Name == "datadir" {
+					claim = c.DeepCopy()
+				}
+			}
+			Expect(claim).NotTo(BeNil())
+
+			for i := 0; i < 5; i++ {
+				size := liveSize
+				if i >= int(cr.Spec.MySQL.Size) {
+					size = orphanSize
+				}
+
+				pvc := claim.DeepCopy()
+				pvc.Labels = exposer.MatchLabels()
+				pvc.Name = fmt.Sprintf("datadir-%s-%d", sts.Name, i)
+				pvc.Namespace = ns
+				pvc.Spec.VolumeName = fmt.Sprintf("pv-orphan-%s-%d", sts.Name, i)
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = size
+				storageClassName := "orphan-storage-class"
+				pvc.Spec.StorageClassName = &storageClassName
+				Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc); err != nil {
+						return false
+					}
+					pvc.Status.Phase = corev1.ClaimBound
+					pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: size}
+					return k8sClient.Status().Update(ctx, pvc) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+			}
+		})
+
+		It("should create a pod for every live PVC only", func() {
+			exposer := mysql.Exposer(*cr)
+			for i := 0; i < int(cr.Spec.MySQL.Size); i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-%d", sts.Name, i),
+						Namespace: ns,
+						Labels:    exposer.MatchLabels(),
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			}
+		})
+
+		It("should not start a resize when every live PVC already has the requested size", func() {
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+			Expect(exists).To(BeFalse(), "orphaned PVCs must not trigger a resize")
+		})
+
+		It("should not delete the StatefulSet", func() {
+			// envtest runs no garbage collector, so an orphan-propagation delete
+			// leaves the object behind with a deletion timestamp instead of
+			// removing it. Existence alone therefore proves nothing.
+			for i := 0; i < 3; i++ {
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+				Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed(), "statefulset should not be deleted in a loop")
+				Expect(sts.DeletionTimestamp).To(BeNil(), "statefulset should not be deleted in a loop")
+			}
+		})
+
+		// A scale up reuses the leftover PVCs. They must be expanded before their
+		// replica is created, otherwise the new replica clones data onto a volume
+		// that is still too small.
+		When("the cluster is scaled back up", Ordered, func() {
+			stsUID := ""
+			It("should scale the CR up to 5", func() {
+				Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+				stsUID = string(sts.UID)
+				Expect(stsUID).NotTo(BeEmpty())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				cr.Spec.MySQL.Size = 5
+				Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+			})
+
+			It("should expand the leftover PVCs before their pods exist", func() {
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				for i := 3; i < 5; i++ {
+					pvc := &corev1.PersistentVolumeClaim{}
+					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					Expect(k8sClient.Get(ctx, key, pvc)).Should(Succeed())
+					requested := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+					Expect(requested.Cmp(liveSize)).To(Equal(0), "leftover PVC should be expanded before its replica is created")
+
+					pod := &corev1.Pod{}
+					podKey := types.NamespacedName{Name: fmt.Sprintf("%s-%d", sts.Name, i), Namespace: ns}
+					err := k8sClient.Get(ctx, podKey, pod)
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "the replica should not exist yet")
+				}
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+				Expect(exists).To(BeTrue(), "resize should be marked as in progress")
+			})
+
+			It("should hold the StatefulSet at its current size while resizing", func() {
+				_, err := reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+				Expect(sts.Spec.Replicas).To(gs.PointTo(BeEquivalentTo(3)), "the new replicas must wait for the resize")
+			})
+
+			It("should finish the resize once the volumes are expanded", func() {
+				// the volume is expanded, only the filesystem is still to be grown,
+				// which kubelet does when the replica mounts it
+				for i := 3; i < 5; i++ {
+					pvc := &corev1.PersistentVolumeClaim{}
+					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, key, pvc); err != nil {
+							return false
+						}
+						pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+							Type:               corev1.PersistentVolumeClaimFileSystemResizePending,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Now(),
+						}}
+						return k8sClient.Status().Update(ctx, pvc) == nil
+					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+				}
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+				Expect(exists).To(BeFalse(), "resize should not block the scale up once the volumes are expanded")
+			})
+
+			It("should not recreate the StatefulSet when its volume template is already correct", func() {
+				Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+				Expect(string(sts.UID)).To(Equal(stsUID), "recreating the statefulset costs a needless rolling restart")
+				Expect(sts.DeletionTimestamp).To(BeNil(), "recreating the statefulset costs a needless rolling restart")
+			})
+
+			It("should let the StatefulSet scale up afterwards", func() {
+				Eventually(func() bool {
+					if _, err := reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName}); err != nil {
+						return false
+					}
+					if err := k8sClient.Get(ctx, stsName, sts); err != nil {
+						return false
+					}
+					return sts.Spec.Replicas != nil && *sts.Spec.Replicas == 5
+				}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+			})
+		})
+
+		// The statefulset must still be recreated when its volume claim template is
+		// stale, since that template is immutable.
+		When("the requested size no longer matches the volume template", Ordered, func() {
+			biggerSize := resource.MustParse("4Gi")
+			stsUID := ""
+
+			It("should request a bigger volume", func() {
+				Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+				stsUID = string(sts.UID)
+				configured := sts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+				Expect(configured.Cmp(biggerSize)).NotTo(Equal(0), "volume template should be stale for this case")
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = biggerSize
+				Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+			})
+
+			It("should resize every PVC of the cluster", func() {
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				for i := 0; i < 5; i++ {
+					pvc := &corev1.PersistentVolumeClaim{}
+					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, key, pvc); err != nil {
+							return false
+						}
+						pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: biggerSize}
+						return k8sClient.Status().Update(ctx, pvc) == nil
+					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+				}
+			})
+
+			It("should recreate the StatefulSet to update the stale volume template", func() {
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				cur := &appsv1.StatefulSet{}
+				err := k8sClient.Get(ctx, stsName, cur)
+				deleted := k8serrors.IsNotFound(err) ||
+					(err == nil && (string(cur.UID) != stsUID || cur.DeletionTimestamp != nil))
+				Expect(deleted).To(BeTrue(), "a stale volume template must still force a recreate")
+			})
+		})
+	})
+})

--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -2375,7 +2375,7 @@ var _ = Describe("PVC Resizing with orphaned PVCs", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		cr.Spec.VolumeExpansionEnabled = true
+		cr.Spec.StorageScaling = &psv1.StorageScalingSpec{EnableVolumeScaling: true}
 		orphanSize := resource.MustParse("2Gi")
 		liveSize := resource.MustParse("3Gi")
 		cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = liveSize
@@ -2539,11 +2539,10 @@ var _ = Describe("PVC Resizing with orphaned PVCs", Ordered, func() {
 						if err := k8sClient.Get(ctx, key, pvc); err != nil {
 							return false
 						}
-						pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
-							Type:               corev1.PersistentVolumeClaimFileSystemResizePending,
-							Status:             corev1.ConditionTrue,
-							LastTransitionTime: metav1.Now(),
-						}}
+						pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: liveSize}
+						pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+							corev1.ResourceStorage: corev1.PersistentVolumeClaimNodeResizePending,
+						}
 						return k8sClient.Status().Update(ctx, pvc) == nil
 					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
 				}
@@ -2599,11 +2598,20 @@ var _ = Describe("PVC Resizing with orphaned PVCs", Ordered, func() {
 				for i := 0; i < 5; i++ {
 					pvc := &corev1.PersistentVolumeClaim{}
 					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					mounted := i < int(cr.Spec.MySQL.Size) && i < 3
 					Eventually(func() bool {
 						if err := k8sClient.Get(ctx, key, pvc); err != nil {
 							return false
 						}
-						pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: biggerSize}
+						if mounted {
+							pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: biggerSize}
+						} else {
+							// no replica mounts it, so only the volume grows
+							pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: biggerSize}
+							pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+								corev1.ResourceStorage: corev1.PersistentVolumeClaimNodeResizePending,
+							}
+						}
 						return k8sClient.Status().Update(ctx, pvc) == nil
 					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
 				}
@@ -2619,6 +2627,207 @@ var _ = Describe("PVC Resizing with orphaned PVCs", Ordered, func() {
 					(err == nil && (string(cur.UID) != stsUID || cur.DeletionTimestamp != nil))
 				Expect(deleted).To(BeTrue(), "a stale volume template must still force a recreate")
 			})
+		})
+	})
+})
+
+var _ = Describe("PVC Resizing with a size that is not whole GiB", Ordered, func() {
+	ctx := context.Background()
+
+	const crName = "pvc-resize-nogib"
+	const ns = crName
+	crNamespacedName := types.NamespacedName{Name: crName, Namespace: ns}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ns,
+			Namespace: ns,
+		},
+	}
+
+	BeforeAll(func() {
+		Expect(k8sClient.Create(ctx, namespace)).To(Not(HaveOccurred()))
+	})
+
+	AfterAll(func() {
+		_ = k8sClient.Delete(ctx, namespace)
+	})
+
+	// PVCs are resized to whole GiB while the volume claim template keeps the
+	// size as written in the spec, and a replica that never mounted its volume
+	// can carry a stale resize status from an earlier expansion.
+	Context("a replica has no pod and the request is rounded up", Ordered, func() {
+		cr, err := readDefaultCR(crName, ns)
+
+		It("should read default cr.yaml", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		specSize := resource.MustParse("2500Mi") // what the template holds
+		roundedSize := resource.MustParse("3Gi") // what the PVCs are resized to
+		cr.Spec.StorageScaling = &psv1.StorageScalingSpec{EnableVolumeScaling: true}
+		cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = specSize
+
+		It("should create PerconaServerMySQL", func() {
+			Expect(k8sClient.Create(ctx, cr)).Should(Succeed())
+		})
+
+		It("should reconcile to create StatefulSet", func() {
+			_, err := reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		sts := &appsv1.StatefulSet{}
+		stsName := types.NamespacedName{Name: cr.Name + "-mysql", Namespace: ns}
+		It("should create MySQL StatefulSet with the size as written", func() {
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, stsName, sts) == nil
+			}, time.Second*15, time.Millisecond*250).Should(BeTrue())
+
+			configured := sts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+			Expect(configured.Cmp(specSize)).To(Equal(0), "the template holds the unrounded size")
+		})
+
+		It("should create StorageClass that supports volume expansion", func() {
+			allowVolumeExpansion := true
+			sc := &storagev1.StorageClass{
+				ObjectMeta:           metav1.ObjectMeta{Name: "nogib-storage-class"},
+				Provisioner:          "kubernetes.io/no-provisioner",
+				AllowVolumeExpansion: &allowVolumeExpansion,
+			}
+			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+		})
+
+		It("should create PVCs, and a pod for all but the last replica", func() {
+			exposer := mysql.Exposer(*cr)
+			var claim *corev1.PersistentVolumeClaim
+			for _, c := range sts.Spec.VolumeClaimTemplates {
+				if c.Name == "datadir" {
+					claim = c.DeepCopy()
+				}
+			}
+			Expect(claim).NotTo(BeNil())
+
+			for i := 0; i < int(cr.Spec.MySQL.Size); i++ {
+				pvc := claim.DeepCopy()
+				pvc.Labels = exposer.MatchLabels()
+				pvc.Name = fmt.Sprintf("datadir-%s-%d", sts.Name, i)
+				pvc.Namespace = ns
+				pvc.Spec.VolumeName = fmt.Sprintf("pv-nogib-%s-%d", sts.Name, i)
+				storageClassName := "nogib-storage-class"
+				pvc.Spec.StorageClassName = &storageClassName
+				Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc); err != nil {
+						return false
+					}
+					pvc.Status.Phase = corev1.ClaimBound
+					pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: specSize}
+					return k8sClient.Status().Update(ctx, pvc) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+			}
+
+			// the last replica has no pod, so its volume is never mounted
+			for i := 0; i < int(cr.Spec.MySQL.Size)-1; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-%d", sts.Name, i),
+						Namespace: ns,
+						Labels:    exposer.MatchLabels(),
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			}
+		})
+
+		lastPVC := types.NamespacedName{}
+		It("should resize every PVC up to whole GiB", func() {
+			lastPVC = types.NamespacedName{
+				Name:      fmt.Sprintf("datadir-%s-%d", sts.Name, int(cr.Spec.MySQL.Size)-1),
+				Namespace: ns,
+			}
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			Expect(k8sClient.Get(ctx, lastPVC, pvc)).Should(Succeed())
+			requested := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			Expect(requested.Cmp(roundedSize)).To(Equal(0))
+		})
+
+		It("should not treat a stale resize status as the current resize", func() {
+			// The volume of the pod-less replica was expanded to the OLD size by an
+			// earlier resize and never mounted since, so it still reports
+			// NodeResizePending and the sticky FileSystemResizePending condition
+			// while allocatedResources lags behind the new request.
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, lastPVC, pvc); err != nil {
+					return false
+				}
+				pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: specSize}
+				pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+					corev1.ResourceStorage: corev1.PersistentVolumeClaimNodeResizePending,
+				}
+				pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+					Type:               corev1.PersistentVolumeClaimFileSystemResizePending,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+				}}
+				return k8sClient.Status().Update(ctx, pvc) == nil
+			}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+			// the mounted ones are done
+			for i := 0; i < int(cr.Spec.MySQL.Size)-1; i++ {
+				p := &corev1.PersistentVolumeClaim{}
+				key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, key, p); err != nil {
+						return false
+					}
+					p.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: roundedSize}
+					return k8sClient.Status().Update(ctx, p) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+			}
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+			Expect(exists).To(BeTrue(), "the volume has not been expanded for this request yet")
+		})
+
+		It("should finish and leave the StatefulSet alone once the volume is expanded", func() {
+			Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+			stsUID := string(sts.UID)
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, lastPVC, pvc); err != nil {
+					return false
+				}
+				pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: roundedSize}
+				return k8sClient.Status().Update(ctx, pvc) == nil
+			}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+			_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+			Expect(exists).To(BeFalse(), "resize should be complete")
+
+			// the template already holds the size as written in the spec, so
+			// recreating the statefulset would restart the replicas for nothing
+			Expect(k8sClient.Get(ctx, stsName, sts)).Should(Succeed())
+			Expect(string(sts.UID)).To(Equal(stsUID), "template matches the spec, no recreate needed")
+			Expect(sts.DeletionTimestamp).To(BeNil(), "template matches the spec, no recreate needed")
 		})
 	})
 })

--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -2831,8 +2831,9 @@ var _ = Describe("PVC Resizing with a size that is not whole GiB", Ordered, func
 		})
 
 		// Wherever RecoverVolumeExpansionFailure is off the per request resize
-		// status is not reported at all, and a resize that never finishes holds the
-		// replicas back for good.
+		// status is not reported at all. The event of this resize is then the only
+		// sign that the volume is expanded, and a resize that never finishes holds
+		// the replicas back for good.
 		When("the cluster reports no resize status", Ordered, func() {
 			lastSize := resource.MustParse("6Gi")
 
@@ -2843,9 +2844,9 @@ var _ = Describe("PVC Resizing with a size that is not whole GiB", Ordered, func
 
 				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
 				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
-			})
 
-			It("should finish the resize from the condition alone", func() {
+				// the mounted claims are done, the pod-less one reports no status at
+				// all and keeps a condition left over from the previous expansion
 				for i := 0; i < int(cr.Spec.MySQL.Size)-1; i++ {
 					p := &corev1.PersistentVolumeClaim{}
 					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
@@ -2868,17 +2869,99 @@ var _ = Describe("PVC Resizing with a size that is not whole GiB", Ordered, func
 					pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 						Type:               corev1.PersistentVolumeClaimFileSystemResizePending,
 						Status:             corev1.ConditionTrue,
-						LastTransitionTime: metav1.Now(),
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
 					}}
 					return k8sClient.Status().Update(ctx, pvc) == nil
 				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+			})
 
+			It("should finish from the condition where no status is reported", func() {
 				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
 				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
 
 				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
 				_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
 				Expect(exists).To(BeFalse(), "a resize that never finishes holds the replicas back")
+			})
+
+			It("should not start the resize over again", func() {
+				// the claim reports a capacity below the request until a replica
+				// mounts it, so a size read that disagrees with the one that ended
+				// the resize starts it again, and the replicas never arrive
+				for i := 0; i < 3; i++ {
+					Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+					Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+					Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+					_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+					Expect(exists).To(BeFalse(), "the resize must not be started over")
+				}
+			})
+		})
+
+		// A claim can already be bigger than the request, for instance after a
+		// resize that only some of them completed. It needs no expansion, and it
+		// can never shrink to match, so it has to count as done.
+		When("a claim is already bigger than the request", Ordered, func() {
+			bigger := resource.MustParse("8Gi")
+			biggest := resource.MustParse("10Gi")
+
+			It("should start a resize with one claim already past it", func() {
+				first := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-0", sts.Name), Namespace: ns}
+				p := &corev1.PersistentVolumeClaim{}
+
+				// grow it past the size that is about to be requested, spec and all,
+				// so that asking it to match would be a shrink the API refuses
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, first, p); err != nil {
+						return false
+					}
+					p.Spec.Resources.Requests[corev1.ResourceStorage] = biggest
+					return k8sClient.Update(ctx, p) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, first, p); err != nil {
+						return false
+					}
+					p.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: biggest}
+					return k8sClient.Status().Update(ctx, p) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = bigger
+				Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				// it must not be asked to shrink, which the API would refuse
+				Expect(k8sClient.Get(ctx, first, p)).Should(Succeed())
+				requested := p.Spec.Resources.Requests[corev1.ResourceStorage]
+				Expect(requested.Cmp(biggest)).To(Equal(0), "a bigger claim must be left alone")
+			})
+
+			It("should finish once the smaller claims caught up", func() {
+				for i := 1; i < int(cr.Spec.MySQL.Size); i++ {
+					p := &corev1.PersistentVolumeClaim{}
+					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, key, p); err != nil {
+							return false
+						}
+						p.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: bigger}
+						p.Status.AllocatedResources = nil
+						p.Status.AllocatedResourceStatuses = nil
+						return k8sClient.Status().Update(ctx, p) == nil
+					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+				}
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+				Expect(exists).To(BeFalse(), "a claim that needs no expansion must not hold the resize open")
 			})
 		})
 	})

--- a/pkg/controller/ps/controller_test.go
+++ b/pkg/controller/ps/controller_test.go
@@ -2829,5 +2829,57 @@ var _ = Describe("PVC Resizing with a size that is not whole GiB", Ordered, func
 			Expect(string(sts.UID)).To(Equal(stsUID), "template matches the spec, no recreate needed")
 			Expect(sts.DeletionTimestamp).To(BeNil(), "template matches the spec, no recreate needed")
 		})
+
+		// Wherever RecoverVolumeExpansionFailure is off the per request resize
+		// status is not reported at all, and a resize that never finishes holds the
+		// replicas back for good.
+		When("the cluster reports no resize status", Ordered, func() {
+			lastSize := resource.MustParse("6Gi")
+
+			It("should request a bigger volume", func() {
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = lastSize
+				Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+			})
+
+			It("should finish the resize from the condition alone", func() {
+				for i := 0; i < int(cr.Spec.MySQL.Size)-1; i++ {
+					p := &corev1.PersistentVolumeClaim{}
+					key := types.NamespacedName{Name: fmt.Sprintf("datadir-%s-%d", sts.Name, i), Namespace: ns}
+					Eventually(func() bool {
+						if err := k8sClient.Get(ctx, key, p); err != nil {
+							return false
+						}
+						p.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: lastSize}
+						return k8sClient.Status().Update(ctx, p) == nil
+					}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+				}
+
+				pvc := &corev1.PersistentVolumeClaim{}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, lastPVC, pvc); err != nil {
+						return false
+					}
+					pvc.Status.AllocatedResources = nil
+					pvc.Status.AllocatedResourceStatuses = nil
+					pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+						Type:               corev1.PersistentVolumeClaimFileSystemResizePending,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					}}
+					return k8sClient.Status().Update(ctx, pvc) == nil
+				}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				Expect(reconciler().reconcilePersistentVolumes(ctx, cr)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, crNamespacedName, cr)).Should(Succeed())
+				_, exists := cr.GetAnnotations()[string(naming.AnnotationPVCResizeInProgress)]
+				Expect(exists).To(BeFalse(), "a resize that never finishes holds the replicas back")
+			})
+		})
 	})
 })

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -108,16 +108,6 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		return nil
 	}
 
-	podList := corev1.PodList{}
-	if err := r.List(ctx, &podList, client.InNamespace(cr.Namespace), client.MatchingLabels(ls)); err != nil {
-		return errors.Wrap(err, "list pods")
-	}
-
-	podNames := make([]string, 0, len(podList.Items))
-	for _, pod := range podList.Items {
-		podNames = append(podNames, pod.Name)
-	}
-
 	// Picked by ordinal, not by the presence of a pod: a scale up must expand the
 	// PVCs it is about to reuse before their replica starts cloning into them.
 	pvcsToUpdate := make([]string, 0, len(pvcList.Items))
@@ -144,11 +134,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 			continue
 		}
 
-		if pvc.Status.Capacity == nil || pvc.Status.Capacity.Storage() == nil {
-			continue
-		}
-
-		size := pvcSize(pvc, isPVCMounted(pvc, stsName, podNames))
+		size := pvcSize(pvc)
 
 		// we need to find the smallest size among all PVCs
 		// since it indicates a failed resize operation
@@ -208,15 +194,9 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 				continue
 			}
 
-			mounted := isPVCMounted(pvc, stsName, podNames)
-
-			if pvcSize(pvc, mounted).Cmp(requested) == 0 {
+			if pvcSize(pvc).Cmp(requested) >= 0 {
 				updatedPVCs++
-				if mounted {
-					log.Info("PVC resize finished", "name", pvc.Name, "size", pvc.Status.Capacity.Storage())
-				} else {
-					log.Info("PVC expanded, filesystem will be resized once the replica starts", "name", pvc.Name, "requested", requested)
-				}
+				log.Info("PVC resize finished", "name", pvc.Name, "size", pvcSize(pvc))
 				continue
 			}
 
@@ -241,17 +221,15 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 			}
 
 			for _, event := range events.Items {
-				eventTime := event.EventTime.Time
-				if event.EventTime.IsZero() {
-					eventTime = event.DeprecatedFirstTimestamp.Time
-				}
-
-				if eventTime.Before(resizeStartedAt) {
+				if lastSeen(event).Before(resizeStartedAt) {
 					continue
 				}
 
 				switch event.Reason {
-				case "Resizing", "ExternalExpanding", "FileSystemResizeRequired":
+				case "Resizing", "ExternalExpanding":
+					log.Info("PVC resize in progress", "pvc", pvc.Name, "reason", event.Reason, "message", event.Note)
+					pendingResize = true
+				case "FileSystemResizeRequired":
 					log.Info("PVC resize in progress", "pvc", pvc.Name, "reason", event.Reason, "message", event.Note)
 					pendingResize = true
 				case "FileSystemResizeSuccessful":
@@ -263,6 +241,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 					continue
 				}
 			}
+
 		}
 
 		if len(resizeErrors) > 0 {
@@ -317,11 +296,14 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		return nil
 	}
 
-	now := metav1.Now().Format(time.RFC3339)
+	// stamped once per resize, so the events belonging to it stay in the window
+	if !cr.PVCResizeInProgress() {
+		now := metav1.Now().Format(time.RFC3339)
 
-	err = k8s.AnnotateObject(ctx, r.Client, cr, map[naming.AnnotationKey]string{naming.AnnotationPVCResizeInProgress: now})
-	if err != nil {
-		return errors.Wrap(err, "annotate ps")
+		err = k8s.AnnotateObject(ctx, r.Client, cr, map[naming.AnnotationKey]string{naming.AnnotationPVCResizeInProgress: now})
+		if err != nil {
+			return errors.Wrap(err, "annotate ps")
+		}
 	}
 
 	log.Info("Resizing PVCs", "requested", requested, "actual", actual, "pvcList", strings.Join(pvcsToUpdate, ","))
@@ -331,7 +313,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 			continue
 		}
 
-		if pvcSize(pvc, isPVCMounted(pvc, stsName, podNames)).Cmp(requested) == 0 {
+		if pvcSize(pvc).Cmp(requested) >= 0 {
 			log.Info("PVC already resized", "name", pvc.Name, "actual", pvc.Status.Capacity.Storage(), "requested", requested)
 			continue
 		}
@@ -417,34 +399,69 @@ func pvcOrdinal(pvcName, stsName string) (int, bool) {
 	return ordinal, true
 }
 
-// isPVCMounted reports whether the replica that mounts the PVC exists.
-func isPVCMounted(pvc corev1.PersistentVolumeClaim, stsName string, podNames []string) bool {
-	return slices.Contains(podNames, extractPodNameFromPVC(pvc.Name, stsName))
+// filesystemResizePending reports that the volume is expanded and only its
+// filesystem is still to be grown. Unlike nodeResizePending this sticks around
+// until the volume is mounted, so it can outlive the resize that set it.
+func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
+	for _, condition := range pvc.Status.Conditions {
+		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }
 
-// pvcSize reports the size of the volume behind the PVC. One that no replica
-// mounts keeps reporting its old capacity until kubelet grows its filesystem on
-// mount, so its allocated size is what it actually has. The allocated size is
-// used rather than the requested one because a new request lands in the spec at
-// once, while allocatedResources only follows when the resize controller picks
-// it up.
-func pvcSize(pvc corev1.PersistentVolumeClaim, mounted bool) *resource.Quantity {
-	if mounted {
-		return pvc.Status.Capacity.Storage()
+// lastSeen reports when the event was last seen. Repeated events are coalesced
+// into one object that keeps its first timestamp and only moves the last one, so
+// the first timestamp can predate the resize that made the event recur.
+func lastSeen(event eventsv1.Event) time.Time {
+	times := []time.Time{
+		event.EventTime.Time,
+		event.DeprecatedLastTimestamp.Time,
+		event.DeprecatedFirstTimestamp.Time,
+		event.CreationTimestamp.Time,
+	}
+	if event.Series != nil {
+		times = append(times, event.Series.LastObservedTime.Time)
 	}
 
-	if reportsResizeStatus(pvc) {
-		if nodeResizePending(pvc) {
-			return pvc.Status.AllocatedResources.Storage()
+	var latest time.Time
+	for _, t := range times {
+		if t.After(latest) {
+			latest = t
 		}
-
-		return pvc.Status.Capacity.Storage()
 	}
 
-	// Nothing reports which request the volume was expanded for. The condition can
-	// outlive the resize that set it, reporting a volume as expanded early, but
-	// waiting for a size the cluster never reports would hold the replica forever.
-	if filesystemResizePending(pvc) {
+	return latest
+}
+
+// pvcSize reports the size of the volume behind the PVC. It deliberately does
+// not look at pods: a claim keeps reporting its old capacity until kubelet grows
+// its filesystem on mount, and whether a pod object exists says nothing about
+// whether that has happened yet.
+//
+// The allocated size is used rather than the requested one because a new request
+// lands in the spec at once, while allocatedResources only follows when the
+// resize controller picks it up.
+func pvcSize(pvc corev1.PersistentVolumeClaim) *resource.Quantity {
+	// An unbound claim has no volume to expand: it is created at the size its
+	// spec asks for, so that is the size it is going to have.
+	if pvc.Status.Capacity.Storage().IsZero() {
+		return pvc.Spec.Resources.Requests.Storage()
+	}
+
+	// the volume is expanded and only its filesystem is still to be grown
+	if nodeResizePending(pvc) {
+		return pvc.Status.AllocatedResources.Storage()
+	}
+
+	// Where nothing reports the per request status this condition is all there
+	// is. It can be left over from an earlier expansion, so the volume may turn
+	// out to be smaller than asked for, which the next resize picks up once a
+	// replica mounts it and its capacity is known again. Ignoring it instead
+	// leaves the claim below the request for good, which holds the replicas back.
+	if !reportsResizeStatus(pvc) && filesystemResizePending(pvc) {
 		return pvc.Spec.Resources.Requests.Storage()
 	}
 
@@ -464,19 +481,6 @@ func nodeResizePending(pvc corev1.PersistentVolumeClaim) bool {
 func reportsResizeStatus(pvc corev1.PersistentVolumeClaim) bool {
 	_, ok := pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage]
 	return ok
-}
-
-// filesystemResizePending reports the same as nodeResizePending, from a condition
-// that sticks around until the volume is mounted. Only used where nothing better
-// is reported.
-func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
-	for _, condition := range pvc.Status.Conditions {
-		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
 }
 
 func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -226,10 +226,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 				}
 
 				switch event.Reason {
-				case "Resizing", "ExternalExpanding":
-					log.Info("PVC resize in progress", "pvc", pvc.Name, "reason", event.Reason, "message", event.Note)
-					pendingResize = true
-				case "FileSystemResizeRequired":
+				case "Resizing", "ExternalExpanding", "FileSystemResizeRequired":
 					log.Info("PVC resize in progress", "pvc", pvc.Name, "reason", event.Reason, "message", event.Note)
 					pendingResize = true
 				case "FileSystemResizeSuccessful":
@@ -257,8 +254,9 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 
 		resizeSucceeded := updatedPVCs == len(pvcsToUpdate)
 		if resizeSucceeded {
-			// The statefulset is only recreated to update its immutable volume
-			// claim template, and doing so costs a rolling restart of the replicas.
+			// Recreated only to update the immutable volume claim template. The
+			// delete orphans the pods and the new set adopts them back, but its
+			// controller revision differs, which makes the smart update roll them.
 			if configured.Cmp(crRequest) != 0 {
 				log.Info("Deleting statefulset", "configured", configured, "requested", crRequest)
 
@@ -403,13 +401,9 @@ func pvcOrdinal(pvcName, stsName string) (int, bool) {
 // filesystem is still to be grown. Unlike nodeResizePending this sticks around
 // until the volume is mounted, so it can outlive the resize that set it.
 func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
-	for _, condition := range pvc.Status.Conditions {
-		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(pvc.Status.Conditions, func(c corev1.PersistentVolumeClaimCondition) bool {
+		return c.Type == corev1.PersistentVolumeClaimFileSystemResizePending && c.Status == corev1.ConditionTrue
+	})
 }
 
 // lastSeen reports when the event was last seen. Repeated events are coalesced

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -185,6 +185,12 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 
 	configured := volumeTemplate.Spec.Resources.Requests[corev1.ResourceStorage]
 	requested := cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage]
+
+	// the volume claim template is rendered from the spec as written, so this is
+	// what an up to date template holds, unlike the rounded up size the PVCs are
+	// resized to
+	crRequest := requested.DeepCopy()
+
 	gib, err := RoundUpGiB(requested.Value())
 	if err != nil {
 		return errors.Wrap(err, "round GiB value")
@@ -277,11 +283,11 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		resizeSucceeded := updatedPVCs == len(pvcsToUpdate)
 		if resizeSucceeded {
 			// The statefulset is only recreated to update its volume claim
-			// template, which is immutable. When the template already asks for the
-			// requested size there is nothing to update, and recreating it would
+			// template, which is immutable. When the template already asks for what
+			// the spec asks for there is nothing to update, and recreating it would
 			// cost a rolling restart of the replicas for nothing.
-			if configured.Cmp(requested) != 0 {
-				log.Info("Deleting statefulset", "configured", configured, "requested", requested)
+			if configured.Cmp(crRequest) != 0 {
+				log.Info("Deleting statefulset", "configured", configured, "requested", crRequest)
 
 				if err := r.Delete(ctx, sts, client.PropagationPolicy("Orphan")); err != nil && !k8serrors.IsNotFound(err) {
 					return errors.Wrapf(err, "delete statefulset/%s", sts.Name)
@@ -417,26 +423,29 @@ func isPVCMounted(pvc corev1.PersistentVolumeClaim, stsName string, podNames []s
 }
 
 // pvcSize reports the size of the volume behind the PVC. A PVC that no replica
-// mounts keeps reporting its old capacity until kubelet grows its filesystem, so
-// once its volume is expanded the requested size is what it actually has.
+// mounts keeps reporting its old capacity until kubelet grows its filesystem on
+// mount, so for those the size the resize controller has already allocated is
+// what the volume actually has.
+//
+// The allocated size is used rather than the requested one on purpose: a new
+// request lands in the spec immediately, while allocatedResources only follows
+// once the resize controller works on that request. Reading the spec here would
+// report a volume as expanded before it is.
 func pvcSize(pvc corev1.PersistentVolumeClaim, mounted bool) *resource.Quantity {
-	if !mounted && filesystemResizePending(pvc) {
-		return pvc.Spec.Resources.Requests.Storage()
+	if !mounted && nodeResizePending(pvc) {
+		return pvc.Status.AllocatedResources.Storage()
 	}
 
 	return pvc.Status.Capacity.Storage()
 }
 
-// filesystemResizePending reports whether the volume behind the PVC is already
-// expanded and only its filesystem is still waiting to be grown.
-func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
-	for _, condition := range pvc.Status.Conditions {
-		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
+// nodeResizePending reports whether the volume behind the PVC is expanded up to
+// its allocated size and only the filesystem is still waiting to be grown on a
+// node. Unlike the FileSystemResizePending condition, which sticks around until
+// the volume is mounted and so can outlive the resize that set it, this status
+// is maintained per resize request.
+func nodeResizePending(pvc corev1.PersistentVolumeClaim) bool {
+	return pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage] == corev1.PersistentVolumeClaimNodeResizePending
 }
 
 func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -118,10 +118,8 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		podNames = append(podNames, pod.Name)
 	}
 
-	// PVCs are picked by their ordinal rather than by the presence of their pod.
-	// The ones a scale down left behind sit outside the requested size and can
-	// never be resized, while the ones a scale up is about to reuse still have no
-	// pod but must be resized before their replica starts cloning data into them.
+	// Picked by ordinal, not by the presence of a pod: a scale up must expand the
+	// PVCs it is about to reuse before their replica starts cloning into them.
 	pvcsToUpdate := make([]string, 0, len(pvcList.Items))
 	for _, pvc := range pvcList.Items {
 		if !validatePVCName(pvc, stsName) {
@@ -186,9 +184,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 	configured := volumeTemplate.Spec.Resources.Requests[corev1.ResourceStorage]
 	requested := cr.Spec.MySQL.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage]
 
-	// the volume claim template is rendered from the spec as written, so this is
-	// what an up to date template holds, unlike the rounded up size the PVCs are
-	// resized to
+	// what an up to date volume claim template holds, unlike the rounded up size
 	crRequest := requested.DeepCopy()
 
 	gib, err := RoundUpGiB(requested.Value())
@@ -282,10 +278,8 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 
 		resizeSucceeded := updatedPVCs == len(pvcsToUpdate)
 		if resizeSucceeded {
-			// The statefulset is only recreated to update its volume claim
-			// template, which is immutable. When the template already asks for what
-			// the spec asks for there is nothing to update, and recreating it would
-			// cost a rolling restart of the replicas for nothing.
+			// The statefulset is only recreated to update its immutable volume
+			// claim template, and doing so costs a rolling restart of the replicas.
 			if configured.Cmp(crRequest) != 0 {
 				log.Info("Deleting statefulset", "configured", configured, "requested", crRequest)
 
@@ -414,9 +408,8 @@ func pvcOrdinal(pvcName, stsName string) (int, bool) {
 		return 0, false
 	}
 
-	// A statefulset only ever names a claim after a non negative ordinal written
-	// in its shortest form. Anything else is a claim it can never reuse, and
-	// treating it as one of the replicas would let it hold a resize back.
+	// a statefulset only names claims after a non negative ordinal in its
+	// shortest form, and any other claim it can never reuse
 	if ordinal < 0 || strconv.Itoa(ordinal) != suffix {
 		return 0, false
 	}
@@ -429,30 +422,61 @@ func isPVCMounted(pvc corev1.PersistentVolumeClaim, stsName string, podNames []s
 	return slices.Contains(podNames, extractPodNameFromPVC(pvc.Name, stsName))
 }
 
-// pvcSize reports the size of the volume behind the PVC. A PVC that no replica
+// pvcSize reports the size of the volume behind the PVC. One that no replica
 // mounts keeps reporting its old capacity until kubelet grows its filesystem on
-// mount, so for those the size the resize controller has already allocated is
-// what the volume actually has.
-//
-// The allocated size is used rather than the requested one on purpose: a new
-// request lands in the spec immediately, while allocatedResources only follows
-// once the resize controller works on that request. Reading the spec here would
-// report a volume as expanded before it is.
+// mount, so its allocated size is what it actually has. The allocated size is
+// used rather than the requested one because a new request lands in the spec at
+// once, while allocatedResources only follows when the resize controller picks
+// it up.
 func pvcSize(pvc corev1.PersistentVolumeClaim, mounted bool) *resource.Quantity {
-	if !mounted && nodeResizePending(pvc) {
-		return pvc.Status.AllocatedResources.Storage()
+	if mounted {
+		return pvc.Status.Capacity.Storage()
+	}
+
+	if reportsResizeStatus(pvc) {
+		if nodeResizePending(pvc) {
+			return pvc.Status.AllocatedResources.Storage()
+		}
+
+		return pvc.Status.Capacity.Storage()
+	}
+
+	// Nothing reports which request the volume was expanded for. The condition can
+	// outlive the resize that set it, reporting a volume as expanded early, but
+	// waiting for a size the cluster never reports would hold the replica forever.
+	if filesystemResizePending(pvc) {
+		return pvc.Spec.Resources.Requests.Storage()
 	}
 
 	return pvc.Status.Capacity.Storage()
 }
 
-// nodeResizePending reports whether the volume behind the PVC is expanded up to
-// its allocated size and only the filesystem is still waiting to be grown on a
-// node. Unlike the FileSystemResizePending condition, which sticks around until
-// the volume is mounted and so can outlive the resize that set it, this status
-// is maintained per resize request.
+// nodeResizePending reports whether the volume is expanded up to its allocated
+// size and only its filesystem is still to be grown. Kept per resize request, so
+// it cannot outlive the resize that set it.
 func nodeResizePending(pvc corev1.PersistentVolumeClaim) bool {
 	return pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage] == corev1.PersistentVolumeClaimNodeResizePending
+}
+
+// reportsResizeStatus reports whether the cluster fills in the per request resize
+// status at all. It needs RecoverVolumeExpansionFailure, which is not enabled on
+// every supported platform.
+func reportsResizeStatus(pvc corev1.PersistentVolumeClaim) bool {
+	_, ok := pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage]
+	return ok
+}
+
+// filesystemResizePending reports the same as nodeResizePending, from a condition
+// that sticks around until the volume is mounted. Only used where nothing better
+// is reported.
+func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
+	for _, condition := range pvc.Status.Conditions {
+		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }
 
 func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -414,6 +414,13 @@ func pvcOrdinal(pvcName, stsName string) (int, bool) {
 		return 0, false
 	}
 
+	// A statefulset only ever names a claim after a non negative ordinal written
+	// in its shortest form. Anything else is a claim it can never reuse, and
+	// treating it as one of the replicas would let it hold a resize back.
+	if ordinal < 0 || strconv.Itoa(ordinal) != suffix {
+		return 0, false
+	}
+
 	return ordinal, true
 }
 

--- a/pkg/controller/ps/volumes.go
+++ b/pkg/controller/ps/volumes.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,23 +113,23 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		return errors.Wrap(err, "list pods")
 	}
 
-	if len(podList.Items) < int(cr.Spec.MySQL.Size) {
-		return nil
-	}
-
 	podNames := make([]string, 0, len(podList.Items))
 	for _, pod := range podList.Items {
 		podNames = append(podNames, pod.Name)
 	}
 
+	// PVCs are picked by their ordinal rather than by the presence of their pod.
+	// The ones a scale down left behind sit outside the requested size and can
+	// never be resized, while the ones a scale up is about to reuse still have no
+	// pod but must be resized before their replica starts cloning data into them.
 	pvcsToUpdate := make([]string, 0, len(pvcList.Items))
 	for _, pvc := range pvcList.Items {
 		if !validatePVCName(pvc, stsName) {
 			continue
 		}
 
-		podName := strings.SplitN(pvc.Name, "-", 2)[1]
-		if !slices.Contains(podNames, podName) {
+		ordinal, ok := pvcOrdinal(pvc.Name, stsName)
+		if !ok || ordinal >= int(cr.Spec.MySQL.Size) {
 			continue
 		}
 
@@ -141,7 +142,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 
 	var actual resource.Quantity
 	for _, pvc := range pvcList.Items {
-		if !validatePVCName(pvc, stsName) {
+		if !slices.Contains(pvcsToUpdate, pvc.Name) {
 			continue
 		}
 
@@ -149,10 +150,12 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 			continue
 		}
 
+		size := pvcSize(pvc, isPVCMounted(pvc, stsName, podNames))
+
 		// we need to find the smallest size among all PVCs
 		// since it indicates a failed resize operation
-		if actual.IsZero() || pvc.Status.Capacity.Storage().Cmp(actual) < 0 {
-			actual = *pvc.Status.Capacity.Storage()
+		if actual.IsZero() || size.Cmp(actual) < 0 {
+			actual = *size
 		}
 	}
 
@@ -199,13 +202,19 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 		var resizeErrors []error
 		pendingResize := false
 		for _, pvc := range pvcList.Items {
-			if !validatePVCName(pvc, stsName) {
+			if !slices.Contains(pvcsToUpdate, pvc.Name) {
 				continue
 			}
 
-			if pvc.Status.Capacity.Storage().Cmp(requested) == 0 {
+			mounted := isPVCMounted(pvc, stsName, podNames)
+
+			if pvcSize(pvc, mounted).Cmp(requested) == 0 {
 				updatedPVCs++
-				log.Info("PVC resize finished", "name", pvc.Name, "size", pvc.Status.Capacity.Storage())
+				if mounted {
+					log.Info("PVC resize finished", "name", pvc.Name, "size", pvc.Status.Capacity.Storage())
+				} else {
+					log.Info("PVC expanded, filesystem will be resized once the replica starts", "name", pvc.Name, "requested", requested)
+				}
 				continue
 			}
 
@@ -267,13 +276,16 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 
 		resizeSucceeded := updatedPVCs == len(pvcsToUpdate)
 		if resizeSucceeded {
-			log.Info("Deleting statefulset")
+			// The statefulset is only recreated to update its volume claim
+			// template, which is immutable. When the template already asks for the
+			// requested size there is nothing to update, and recreating it would
+			// cost a rolling restart of the replicas for nothing.
+			if configured.Cmp(requested) != 0 {
+				log.Info("Deleting statefulset", "configured", configured, "requested", requested)
 
-			if err := r.Delete(ctx, sts, client.PropagationPolicy("Orphan")); err != nil {
-				if k8serrors.IsNotFound(err) {
-					return nil
+				if err := r.Delete(ctx, sts, client.PropagationPolicy("Orphan")); err != nil && !k8serrors.IsNotFound(err) {
+					return errors.Wrapf(err, "delete statefulset/%s", sts.Name)
 				}
-				return errors.Wrapf(err, "delete statefulset/%s", sts.Name)
 			}
 
 			if err := k8s.DeannotateObject(ctx, r.Client, cr, naming.AnnotationPVCResizeInProgress); err != nil {
@@ -319,7 +331,7 @@ func (r *PerconaServerMySQLReconciler) reconcilePersistentVolumes(ctx context.Co
 			continue
 		}
 
-		if pvc.Status.Capacity.Storage().Cmp(requested) == 0 {
+		if pvcSize(pvc, isPVCMounted(pvc, stsName, podNames)).Cmp(requested) == 0 {
 			log.Info("PVC already resized", "name", pvc.Name, "actual", pvc.Status.Capacity.Storage(), "requested", requested)
 			continue
 		}
@@ -382,6 +394,49 @@ func (r *PerconaServerMySQLReconciler) revertVolumeTemplate(ctx context.Context,
 	}
 
 	return nil
+}
+
+// pvcOrdinal returns the ordinal of the replica a datadir PVC belongs to.
+func pvcOrdinal(pvcName, stsName string) (int, bool) {
+	suffix, ok := strings.CutPrefix(pvcName, mysql.DataVolumeName+"-"+stsName+"-")
+	if !ok {
+		return 0, false
+	}
+
+	ordinal, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+
+	return ordinal, true
+}
+
+// isPVCMounted reports whether the replica that mounts the PVC exists.
+func isPVCMounted(pvc corev1.PersistentVolumeClaim, stsName string, podNames []string) bool {
+	return slices.Contains(podNames, extractPodNameFromPVC(pvc.Name, stsName))
+}
+
+// pvcSize reports the size of the volume behind the PVC. A PVC that no replica
+// mounts keeps reporting its old capacity until kubelet grows its filesystem, so
+// once its volume is expanded the requested size is what it actually has.
+func pvcSize(pvc corev1.PersistentVolumeClaim, mounted bool) *resource.Quantity {
+	if !mounted && filesystemResizePending(pvc) {
+		return pvc.Spec.Resources.Requests.Storage()
+	}
+
+	return pvc.Status.Capacity.Storage()
+}
+
+// filesystemResizePending reports whether the volume behind the PVC is already
+// expanded and only its filesystem is still waiting to be grown.
+func filesystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
+	for _, condition := range pvc.Status.Conditions {
+		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }
 
 func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {

--- a/pkg/controller/ps/volumes_test.go
+++ b/pkg/controller/ps/volumes_test.go
@@ -2,6 +2,10 @@ package ps
 
 import (
 	"testing"
+	"time"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -53,19 +57,12 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 	requested := resource.MustParse("3Gi")
 
 	tests := []struct {
-		name    string
-		pvc     corev1.PersistentVolumeClaim
-		mounted bool
+		name string
+		pvc  corev1.PersistentVolumeClaim
 	}{
 		{
-			name:    "pending claim with a pod",
-			pvc:     corev1.PersistentVolumeClaim{},
-			mounted: true,
-		},
-		{
-			name:    "pending claim without a pod",
-			pvc:     corev1.PersistentVolumeClaim{},
-			mounted: false,
+			name: "pending claim",
+			pvc:  corev1.PersistentVolumeClaim{},
 		},
 		{
 			// maps that exist but carry no storage entry, which is the case the
@@ -76,7 +73,6 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 					Capacity: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 				},
 			},
-			mounted: true,
 		},
 		{
 			name: "allocatedResources present without a storage entry",
@@ -88,7 +84,6 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 					},
 				},
 			},
-			mounted: false,
 		},
 		{
 			// the branch that reads allocatedResources, before that map is filled
@@ -100,13 +95,12 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 					},
 				},
 			},
-			mounted: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			size := pvcSize(tt.pvc, tt.mounted)
+			size := pvcSize(tt.pvc)
 			if size == nil {
 				t.Fatal("pvcSize returned nil, callers dereference it")
 			}
@@ -122,8 +116,8 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 
 // Not every platform fills in allocatedResourceStatuses: it needs
 // RecoverVolumeExpansionFailure, which is off on some supported Kubernetes
-// versions. Where it is reported it must be used, because it cannot outlive the
-// resize that set it, and where it is not the condition has to do.
+// versions. Where it is reported it wins, because it cannot outlive the resize
+// that set it; where it is not, the sticky condition is all there is.
 func TestPVCSizeSignals(t *testing.T) {
 	const (
 		old = "3Gi"
@@ -162,17 +156,10 @@ func TestPVCSizeSignals(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		pvc     corev1.PersistentVolumeClaim
-		mounted bool
-		want    string
+		name string
+		pvc  corev1.PersistentVolumeClaim
+		want string
 	}{
-		{
-			name:    "a mounted claim reports its own capacity",
-			pvc:     pvc(withStatus(corev1.PersistentVolumeClaimNodeResizePending, new)),
-			mounted: true,
-			want:    old,
-		},
 		{
 			name: "the volume is expanded and the node resize is pending",
 			pvc:  pvc(withStatus(corev1.PersistentVolumeClaimNodeResizePending, new)),
@@ -184,8 +171,8 @@ func TestPVCSizeSignals(t *testing.T) {
 			want: old,
 		},
 		{
-			// the condition must not be trusted where the status is reported,
-			// since it can be left over from an earlier expansion
+			// a condition left over from an earlier expansion must never stand in
+			// for the current one, or a replica starts on an undersized volume
 			name: "a leftover condition is ignored when the status is reported",
 			pvc: pvc(func(p *corev1.PersistentVolumeClaim) {
 				withStatus(corev1.PersistentVolumeClaimControllerResizeInProgress, old)(p)
@@ -194,9 +181,19 @@ func TestPVCSizeSignals(t *testing.T) {
 			want: old,
 		},
 		{
-			// platforms that do not report the status at all
+			// the only signal such a platform gives: it may be left over from an
+			// earlier expansion, which the next resize corrects once the volume is
+			// mounted and reports its capacity again
 			name: "the condition is used when no status is reported",
 			pvc:  pvc(withCondition),
+			want: new,
+		},
+		{
+			// nothing to expand yet: it is created at the size it asks for
+			name: "an unbound claim reports the size it asks for",
+			pvc: pvc(func(p *corev1.PersistentVolumeClaim) {
+				p.Status.Capacity = nil
+			}),
 			want: new,
 		},
 		{
@@ -209,9 +206,58 @@ func TestPVCSizeSignals(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			want := resource.MustParse(tt.want)
-			got := pvcSize(tt.pvc, tt.mounted)
+			got := pvcSize(tt.pvc)
 			if got.Cmp(want) != 0 {
 				t.Fatalf("pvcSize = %s, want %s", got, &want)
+			}
+		})
+	}
+}
+
+// Repeated events are coalesced into one object whose first timestamp stays put
+// while the last one moves, and events written through the core API carry no
+// eventTime at all.
+func TestLastSeen(t *testing.T) {
+	first := time.Date(2026, 8, 22, 17, 19, 44, 0, time.UTC)
+	last := time.Date(2026, 8, 22, 17, 25, 19, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		event eventsv1.Event
+		want  time.Time
+	}{
+		{
+			name: "coalesced event with no eventTime",
+			event: eventsv1.Event{
+				DeprecatedFirstTimestamp: metav1.NewTime(first),
+				DeprecatedLastTimestamp:  metav1.NewTime(last),
+			},
+			want: last,
+		},
+		{
+			name:  "a fresh event carries its own time",
+			event: eventsv1.Event{EventTime: metav1.NewMicroTime(last)},
+			want:  last,
+		},
+		{
+			name: "a series reports when it was last observed",
+			event: eventsv1.Event{
+				DeprecatedFirstTimestamp: metav1.NewTime(first),
+				Series:                   &eventsv1.EventSeries{LastObservedTime: metav1.NewMicroTime(last)},
+			},
+			want: last,
+		},
+		{
+			name:  "nothing but a creation timestamp",
+			event: eventsv1.Event{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(first)}},
+			want:  first,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lastSeen(tt.event); !got.Equal(tt.want) {
+				t.Fatalf("lastSeen = %s, want %s", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/ps/volumes_test.go
+++ b/pkg/controller/ps/volumes_test.go
@@ -68,6 +68,29 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 			mounted: false,
 		},
 		{
+			// maps that exist but carry no storage entry, which is the case the
+			// review comment describes, as opposed to the nil maps above
+			name: "capacity present without a storage entry",
+			pvc: corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				},
+			},
+			mounted: true,
+		},
+		{
+			name: "allocatedResources present without a storage entry",
+			pvc: corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					AllocatedResources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					AllocatedResourceStatuses: map[corev1.ResourceName]corev1.ClaimResourceStatus{
+						corev1.ResourceStorage: corev1.PersistentVolumeClaimNodeResizePending,
+					},
+				},
+			},
+			mounted: false,
+		},
+		{
 			// the branch that reads allocatedResources, before that map is filled
 			name: "resize reported before allocatedResources is set",
 			pvc: corev1.PersistentVolumeClaim{
@@ -92,6 +115,103 @@ func TestPVCSizeWithoutCapacity(t *testing.T) {
 			}
 			if size.Cmp(requested) == 0 {
 				t.Fatal("a claim with no capacity must not count as resized")
+			}
+		})
+	}
+}
+
+// Not every platform fills in allocatedResourceStatuses: it needs
+// RecoverVolumeExpansionFailure, which is off on some supported Kubernetes
+// versions. Where it is reported it must be used, because it cannot outlive the
+// resize that set it, and where it is not the condition has to do.
+func TestPVCSizeSignals(t *testing.T) {
+	const (
+		old = "3Gi"
+		new = "4Gi"
+	)
+
+	pvc := func(mutate func(*corev1.PersistentVolumeClaim)) corev1.PersistentVolumeClaim {
+		p := corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(new)},
+				},
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(old)},
+			},
+		}
+		mutate(&p)
+		return p
+	}
+
+	withStatus := func(s corev1.ClaimResourceStatus, allocated string) func(*corev1.PersistentVolumeClaim) {
+		return func(p *corev1.PersistentVolumeClaim) {
+			p.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+				corev1.ResourceStorage: s,
+			}
+			p.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(allocated)}
+		}
+	}
+
+	withCondition := func(p *corev1.PersistentVolumeClaim) {
+		p.Status.Conditions = append(p.Status.Conditions, corev1.PersistentVolumeClaimCondition{
+			Type:   corev1.PersistentVolumeClaimFileSystemResizePending,
+			Status: corev1.ConditionTrue,
+		})
+	}
+
+	tests := []struct {
+		name    string
+		pvc     corev1.PersistentVolumeClaim
+		mounted bool
+		want    string
+	}{
+		{
+			name:    "a mounted claim reports its own capacity",
+			pvc:     pvc(withStatus(corev1.PersistentVolumeClaimNodeResizePending, new)),
+			mounted: true,
+			want:    old,
+		},
+		{
+			name: "the volume is expanded and the node resize is pending",
+			pvc:  pvc(withStatus(corev1.PersistentVolumeClaimNodeResizePending, new)),
+			want: new,
+		},
+		{
+			name: "the volume is still being expanded",
+			pvc:  pvc(withStatus(corev1.PersistentVolumeClaimControllerResizeInProgress, new)),
+			want: old,
+		},
+		{
+			// the condition must not be trusted where the status is reported,
+			// since it can be left over from an earlier expansion
+			name: "a leftover condition is ignored when the status is reported",
+			pvc: pvc(func(p *corev1.PersistentVolumeClaim) {
+				withStatus(corev1.PersistentVolumeClaimControllerResizeInProgress, old)(p)
+				withCondition(p)
+			}),
+			want: old,
+		},
+		{
+			// platforms that do not report the status at all
+			name: "the condition is used when no status is reported",
+			pvc:  pvc(withCondition),
+			want: new,
+		},
+		{
+			name: "no status and no condition means nothing happened yet",
+			pvc:  pvc(func(*corev1.PersistentVolumeClaim) {}),
+			want: old,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := resource.MustParse(tt.want)
+			got := pvcSize(tt.pvc, tt.mounted)
+			if got.Cmp(want) != 0 {
+				t.Fatalf("pvcSize = %s, want %s", got, &want)
 			}
 		})
 	}

--- a/pkg/controller/ps/volumes_test.go
+++ b/pkg/controller/ps/volumes_test.go
@@ -1,0 +1,42 @@
+package ps
+
+import "testing"
+
+func TestPVCOrdinal(t *testing.T) {
+	const stsName = "cluster1-mysql"
+
+	tests := []struct {
+		name    string
+		pvcName string
+		ordinal int
+		ok      bool
+	}{
+		{name: "first replica", pvcName: "datadir-cluster1-mysql-0", ordinal: 0, ok: true},
+		{name: "tenth replica", pvcName: "datadir-cluster1-mysql-9", ordinal: 9, ok: true},
+		{name: "two digit ordinal", pvcName: "datadir-cluster1-mysql-10", ordinal: 10, ok: true},
+
+		{name: "another cluster", pvcName: "datadir-cluster2-mysql-0", ok: false},
+		{name: "another volume", pvcName: "backup-cluster1-mysql-0", ok: false},
+		{name: "no ordinal", pvcName: "datadir-cluster1-mysql-", ok: false},
+		{name: "not a number", pvcName: "datadir-cluster1-mysql-primary", ok: false},
+
+		// a statefulset never creates these, and accepting them would let a claim
+		// no replica can ever use take part in a resize
+		{name: "negative ordinal", pvcName: "datadir-cluster1-mysql--1", ok: false},
+		{name: "explicitly signed ordinal", pvcName: "datadir-cluster1-mysql-+1", ok: false},
+		{name: "zero padded ordinal", pvcName: "datadir-cluster1-mysql-01", ok: false},
+		{name: "negative zero", pvcName: "datadir-cluster1-mysql--0", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ordinal, ok := pvcOrdinal(tt.pvcName, stsName)
+			if ok != tt.ok {
+				t.Fatalf("pvcOrdinal(%q) ok = %v, want %v (ordinal %d)", tt.pvcName, ok, tt.ok, ordinal)
+			}
+			if ok && ordinal != tt.ordinal {
+				t.Fatalf("pvcOrdinal(%q) = %d, want %d", tt.pvcName, ordinal, tt.ordinal)
+			}
+		})
+	}
+}

--- a/pkg/controller/ps/volumes_test.go
+++ b/pkg/controller/ps/volumes_test.go
@@ -1,6 +1,11 @@
 package ps
 
-import "testing"
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 func TestPVCOrdinal(t *testing.T) {
 	const stsName = "cluster1-mysql"
@@ -36,6 +41,57 @@ func TestPVCOrdinal(t *testing.T) {
 			}
 			if ok && ordinal != tt.ordinal {
 				t.Fatalf("pvcOrdinal(%q) = %d, want %d", tt.pvcName, ordinal, tt.ordinal)
+			}
+		})
+	}
+}
+
+// A selected PVC can exist before it reports a capacity, for example a claim
+// that is still Pending during a scale up. Sizing it must not panic, and it must
+// not look like a finished resize, so that the operator waits for the claim.
+func TestPVCSizeWithoutCapacity(t *testing.T) {
+	requested := resource.MustParse("3Gi")
+
+	tests := []struct {
+		name    string
+		pvc     corev1.PersistentVolumeClaim
+		mounted bool
+	}{
+		{
+			name:    "pending claim with a pod",
+			pvc:     corev1.PersistentVolumeClaim{},
+			mounted: true,
+		},
+		{
+			name:    "pending claim without a pod",
+			pvc:     corev1.PersistentVolumeClaim{},
+			mounted: false,
+		},
+		{
+			// the branch that reads allocatedResources, before that map is filled
+			name: "resize reported before allocatedResources is set",
+			pvc: corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					AllocatedResourceStatuses: map[corev1.ResourceName]corev1.ClaimResourceStatus{
+						corev1.ResourceStorage: corev1.PersistentVolumeClaimNodeResizePending,
+					},
+				},
+			},
+			mounted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size := pvcSize(tt.pvc, tt.mounted)
+			if size == nil {
+				t.Fatal("pvcSize returned nil, callers dereference it")
+			}
+			if !size.IsZero() {
+				t.Fatalf("pvcSize = %s, want zero for a claim with no capacity", size)
+			}
+			if size.Cmp(requested) == 0 {
+				t.Fatal("a claim with no capacity must not count as resized")
 			}
 		})
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Scaling a cluster down leaves the PVCs of the removed replicas behind, and reconcilePersistentVolumes took them into account when it decided whether a resize was needed: the current size was the smallest capacity among all datadir PVCs, while only the PVCs that still had a pod were ever resized. Those leftovers therefore kept the current size below the requested one forever, so every reconcile re-requested the same resize, declared it complete and deleted the statefulset again.

PVCs are now picked by their ordinal instead of by the presence of their pod. Leftovers sit outside the requested size and are ignored, which ends the loop. The PVCs a scale up is about to reuse are included even though they have no pod yet, so they are expanded before their replica is created rather than after it has started cloning data onto a volume that is too small. Since the resize annotation keeps reconcileDatabase from touching the statefulset, the new replicas are held back until the volumes are ready, and kubelet grows the filesystem when it mounts them.

A PVC that no pod mounts cannot report the new size, because the filesystem is only grown on mount, so it is treated as resized once its volume is expanded and only the filesystem resize is pending.
The statefulset is now only recreated when its volume claim template is actually out of date. It is recreated to update that immutable template, and doing so when the template already asks for the requested size costs a smart update rolling restart of the replicas for nothing.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
