### PR TITLE
K8SPS-471 leaf cert rotation without restarts

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1116,11 +1116,19 @@ get_mysql_pod_names() {
 		--sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}'
 }
 
+get_component_pod_uids() {
+	local cluster_name=$1
+	local component=$2
+
+	kubectl get pod -n "${NAMESPACE}" \
+		--selector="app.kubernetes.io/instance=${cluster_name},app.kubernetes.io/name=${component}" \
+		--sort-by=.metadata.name -o jsonpath='{.items[*].metadata.uid}'
+}
+
 get_mysql_pod_uids() {
 	local cluster_name=$1
 
-	kubectl get pod -n "${NAMESPACE}" --selector="$(mysql_pod_selector "${cluster_name}")" \
-		--sort-by=.metadata.name -o jsonpath='{.items[*].metadata.uid}'
+	get_component_pod_uids "${cluster_name}" mysql
 }
 
 # Prints the global value of a MySQL variable from every database pod of the
@@ -1172,18 +1180,27 @@ wait_for_mysql_variable() {
 	done
 }
 
-# Waits until every database pod of the given cluster has been replaced,
-# comparing against a UID list captured with get_mysql_pod_uids before the
-# change that should restart them.
 wait_for_mysql_pods_restart() {
 	local cluster_name=$1
 	local uids_before=$2
 	local timeout=${3:-600}
+
+	wait_for_component_pods_restart "${cluster_name}" mysql "${uids_before}" "${timeout}"
+}
+
+# Waits until every pod of the given component has been replaced, comparing
+# against a UID list captured with get_component_pod_uids before the change that
+# should restart them.
+wait_for_component_pods_restart() {
+	local cluster_name=$1
+	local component=$2
+	local uids_before=$3
+	local timeout=${4:-600}
 	local elapsed=0
 	local expected_count=$(echo "${uids_before}" | wc -w)
 
 	while :; do
-		local uids_now=$(get_mysql_pod_uids "${cluster_name}")
+		local uids_now=$(get_component_pod_uids "${cluster_name}" "${component}")
 		local replaced=true
 		local uid
 
@@ -1201,14 +1218,70 @@ wait_for_mysql_pods_restart() {
 			return 0
 		fi
 		if ((elapsed >= timeout)); then
-			echo "Timeout (${timeout}s) exceeded while waiting for ${cluster_name} mysql pods to be replaced"
+			echo "Timeout (${timeout}s) exceeded while waiting for ${cluster_name} ${component} pods to be replaced"
 			echo "uids before: ${uids_before}"
 			echo "uids now:    ${uids_now}"
 			return 1
 		fi
-		echo "waiting for ${cluster_name} mysql pods to be replaced"
+		echo "waiting for ${cluster_name} ${component} pods to be replaced"
 		sleep 10
 		elapsed=$((elapsed + 10))
+	done
+}
+
+# Prints the notBefore date of the certificate mysqld currently serves from every
+# database pod, in pod name order. Spaces inside a date become underscores so
+# that every pod stays one word; unreachable pods print "unavailable".
+get_mysql_cert_not_before_on_pods() {
+	local cluster_name=$1
+	local values=()
+
+	for pod in $(get_mysql_pod_names "${cluster_name}"); do
+		values+=("$(kubectl -n "${NAMESPACE}" exec "${pod}" -c mysql -- bash -c \
+			'mysql -uroot -p"$(cat /etc/mysql/mysql-users-secret/root)" -NB -e "SHOW GLOBAL STATUS LIKE \"Ssl_server_not_before\"" | cut -f2 | tr " " "_"' \
+			2>/dev/null || echo 'unavailable')")
+	done
+
+	echo "${values[*]}"
+}
+
+# Waits until every database pod serves a certificate other than the one in the
+# list captured with get_mysql_cert_not_before_on_pods before the rotation.
+wait_for_mysql_cert_reload() {
+	local cluster_name=$1
+	local not_before_before=$2
+	local timeout=${3:-300}
+	local elapsed=0
+
+	local before=(${not_before_before})
+
+	while :; do
+		local now=($(get_mysql_cert_not_before_on_pods "${cluster_name}"))
+		local reloaded=true
+		local i
+
+		if [[ ${#now[@]} -ne ${#before[@]} ]]; then
+			reloaded=false
+		else
+			for i in "${!now[@]}"; do
+				if [[ ${now[$i]} == "unavailable" || ${now[$i]} == "${before[$i]}" ]]; then
+					reloaded=false
+				fi
+			done
+		fi
+
+		if [[ ${reloaded} == true ]]; then
+			return 0
+		fi
+		if ((elapsed >= timeout)); then
+			echo "Timeout (${timeout}s) exceeded while waiting for ${cluster_name} mysql pods to reload their certificate"
+			echo "not before, before: ${before[*]}"
+			echo "not before, now:    ${now[*]}"
+			return 1
+		fi
+		echo "waiting for ${cluster_name} mysql pods to reload their certificate"
+		sleep 5
+		elapsed=$((elapsed + 5))
 	done
 }
 

--- a/e2e-tests/tests/gr-tls-cert-manager/06-assert.yaml
+++ b/e2e-tests/tests/gr-tls-cert-manager/06-assert.yaml
@@ -2,6 +2,15 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 400
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 06-renew-certs
+data:
+  reloaded: "true"
+  mysql_recycled: "false"
+  router_recycled: "true"
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/e2e-tests/tests/gr-tls-cert-manager/06-renew-certs.yaml
+++ b/e2e-tests/tests/gr-tls-cert-manager/06-renew-certs.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 150
+timeout: 1200
 commands:
   - script: |-
       set -o errexit
@@ -8,4 +8,27 @@ commands:
 
       source ../../functions
 
+      cluster=$(get_cluster_name)
+      mysql_uids_before=$(get_mysql_pod_uids "${cluster}")
+      router_uids_before=$(get_component_pod_uids "${cluster}" router)
+      not_before=$(get_mysql_cert_not_before_on_pods "${cluster}")
+
       renew_certificate "gr-tls-cert-manager-ssl"
+
+      reloaded="true"
+      wait_for_mysql_cert_reload "${cluster}" "${not_before}" 300 || reloaded="false"
+
+      # Router reads its certificates once at startup, so unlike mysqld it still
+      # has to be restarted to pick up the new ones.
+      router_recycled="true"
+      wait_for_component_pods_restart "${cluster}" router "${router_uids_before}" 600 || router_recycled="false"
+
+      # The renewed leaf is signed by the same CA, so no database pod may be
+      # replaced - not even while everything around it rolls.
+      mysql_recycled="false"
+      [[ $(get_mysql_pod_uids "${cluster}") == "${mysql_uids_before}" ]] || mysql_recycled="true"
+
+      kubectl -n "${NAMESPACE}" create configmap 06-renew-certs \
+          --from-literal=reloaded="${reloaded}" \
+          --from-literal=mysql_recycled="${mysql_recycled}" \
+          --from-literal=router_recycled="${router_recycled}"

--- a/e2e-tests/tests/tls-cert-manager/06-assert.yaml
+++ b/e2e-tests/tests/tls-cert-manager/06-assert.yaml
@@ -2,6 +2,15 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 500
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 06-renew-certs
+data:
+  reloaded: "true"
+  mysql_recycled: "false"
+  proxies_recycled: "true"
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/e2e-tests/tests/tls-cert-manager/06-renew-certs.yaml
+++ b/e2e-tests/tests/tls-cert-manager/06-renew-certs.yaml
@@ -1,11 +1,37 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 30
+  - timeout: 1200
     script: |-
       set -o errexit
       set -o xtrace
 
       source ../../functions
 
+      cluster=$(get_cluster_name)
+      mysql_uids_before=$(get_mysql_pod_uids "${cluster}")
+      orc_uids_before=$(get_component_pod_uids "${cluster}" orchestrator)
+      haproxy_uids_before=$(get_component_pod_uids "${cluster}" haproxy)
+      not_before=$(get_mysql_cert_not_before_on_pods "${cluster}")
+
       renew_certificate "tls-cert-manager-ssl"
+
+      reloaded="true"
+      wait_for_mysql_cert_reload "${cluster}" "${not_before}" 300 || reloaded="false"
+
+      # Orchestrator connects to MySQL with a client certificate it reads once at
+      # startup, so unlike mysqld it still has to be restarted to pick up the new
+      # one. HAProxy shares that hash today.
+      proxies_recycled="true"
+      wait_for_component_pods_restart "${cluster}" orchestrator "${orc_uids_before}" 600 || proxies_recycled="false"
+      wait_for_component_pods_restart "${cluster}" haproxy "${haproxy_uids_before}" 600 || proxies_recycled="false"
+
+      # The renewed leaf is signed by the same CA, so no database pod may be
+      # replaced - not even while everything around it rolls.
+      mysql_recycled="false"
+      [[ $(get_mysql_pod_uids "${cluster}") == "${mysql_uids_before}" ]] || mysql_recycled="true"
+
+      kubectl -n "${NAMESPACE}" create configmap 06-renew-certs \
+          --from-literal=reloaded="${reloaded}" \
+          --from-literal=mysql_recycled="${mysql_recycled}" \
+          --from-literal=proxies_recycled="${proxies_recycled}"

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -985,6 +985,10 @@ func (r *PerconaServerMySQLReconciler) reconcileDatabase(ctx context.Context, cr
 		return errors.Wrap(err, "reconcile MySQL config")
 	}
 
+	if err := r.reconcileTLSReload(ctx, cr, sts); err != nil {
+		return errors.Wrap(err, "reconcile TLS reload")
+	}
+
 	return nil
 }
 

--- a/pkg/controller/ps/tls_reload.go
+++ b/pkg/controller/ps/tls_reload.go
@@ -1,0 +1,131 @@
+package ps
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
+	"github.com/percona/percona-server-mysql-operator/pkg/db"
+	"github.com/percona/percona-server-mysql-operator/pkg/k8s"
+	"github.com/percona/percona-server-mysql-operator/pkg/mysql"
+	"github.com/percona/percona-server-mysql-operator/pkg/naming"
+)
+
+// reconcileTLSReload picks up a rotated leaf certificate on the running MySQL pods.
+func (r *PerconaServerMySQLReconciler) reconcileTLSReload(ctx context.Context, cr *apiv1.PerconaServerMySQL, sts *appsv1.StatefulSet) error {
+	if cr.CompareVersion("1.3.0") < 0 {
+		return nil
+	}
+
+	log := logf.FromContext(ctx).WithName("reconcileTLSReload")
+
+	secret := new(corev1.Secret)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      cr.Spec.SSLSecretName,
+		Namespace: cr.Namespace,
+	}, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "get TLS secret")
+	}
+
+	certHash := tlsCertHash(secret)
+	if certHash == "" {
+		return nil
+	}
+
+	writeAnnotation := func() error {
+		if err := k8s.AnnotateObject(ctx, r.Client, sts, map[naming.AnnotationKey]string{
+			naming.AnnotationLastReloadedTLS: certHash,
+		}); err != nil {
+			return errors.Wrap(err, "annotate object")
+		}
+		return nil
+	}
+
+	lastReloaded, ok := sts.Annotations[naming.AnnotationLastReloadedTLS.String()]
+
+	// Pods read the certificates on startup, so a cluster with no hash recorded
+	// yet only needs something to compare against on the next rotation.
+	if !ok || cr.Status.State == apiv1.StateNew {
+		return writeAnnotation()
+	}
+
+	if lastReloaded == certHash {
+		return nil
+	}
+
+	pods, err := k8s.RunningPods(ctx, r.Client, mysql.MatchLabels(cr), cr.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "get running pods")
+	}
+
+	if cr.Spec.Pause || len(pods) < int(cr.Spec.MySQL.Size) {
+		log.Info("Not all pods are running, defer reloading TLS certificates", "running", len(pods), "desired", cr.Spec.MySQL.Size)
+		return nil
+	}
+
+	// kubelet refreshes a mounted secret on its own schedule, so a pod can still
+	// hold the previous certificate, and reloading it now would re-read the old file.
+	for _, pod := range pods {
+		onDisk, err := r.tlsCertHashOnPod(ctx, &pod)
+		if err != nil {
+			return errors.Wrapf(err, "get certificate from pod %s", pod.Name)
+		}
+		if onDisk != certHash {
+			// Certificate is not propagated to the pod yet, defer reloading TLS certificates
+			return nil
+		}
+	}
+
+	operatorPass, err := k8s.UserPassword(ctx, r.Client, cr, apiv1.UserOperator)
+	if err != nil {
+		return errors.Wrap(err, "get operator password")
+	}
+
+	for _, pod := range pods {
+		mgr := db.NewAdminManager(&pod, r.ClientCmd, apiv1.UserOperator, operatorPass, mysql.PodFQDN(cr, &pod))
+		if err := mgr.ReloadTLS(ctx); err != nil {
+			return errors.Wrapf(err, "reload TLS on pod %s", pod.Name)
+		}
+	}
+
+	log.Info("Reloaded TLS certificates without restarting pods", "pods", len(pods))
+
+	return writeAnnotation()
+}
+
+func tlsCertHash(secret *corev1.Secret) string {
+	cert, key := secret.Data[naming.TLSCertKey], secret.Data[naming.TLSKeyKey]
+	if len(cert) == 0 || len(key) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%x", md5.Sum(slices.Concat(cert, key)))
+}
+
+func (r *PerconaServerMySQLReconciler) tlsCertHashOnPod(ctx context.Context, pod *corev1.Pod) (string, error) {
+	cmd := []string{
+		"cat",
+		filepath.Join(mysql.TLSMountPath, naming.TLSCertKey),
+		filepath.Join(mysql.TLSMountPath, naming.TLSKeyKey),
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := r.ClientCmd.Exec(ctx, pod, "mysql", cmd, nil, &stdout, &stderr, false); err != nil {
+		return "", errors.Wrapf(err, "stderr: %s", stderr.String())
+	}
+
+	return fmt.Sprintf("%x", md5.Sum(stdout.Bytes())), nil
+}

--- a/pkg/controller/ps/tls_reload_test.go
+++ b/pkg/controller/ps/tls_reload_test.go
@@ -1,0 +1,352 @@
+package ps
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/percona/percona-server-mysql-operator/api/v1"
+	clientcmdmock "github.com/percona/percona-server-mysql-operator/pkg/clientcmd/mock"
+	"github.com/percona/percona-server-mysql-operator/pkg/mysql"
+	"github.com/percona/percona-server-mysql-operator/pkg/naming"
+)
+
+func TestReconcileTLSReload(t *testing.T) {
+	const (
+		crName       = "cluster1"
+		ns           = "tls-ns"
+		sslSecret    = "cluster1-ssl"
+		operatorPass = "operator-password"
+		podCount     = 3
+		reloadStmt   = "ALTER INSTANCE RELOAD TLS"
+		stderrDenied = "ERROR 1227 (42000): Access denied\n"
+
+		caPEM      = "ca-certificate"
+		certPEM    = "leaf-certificate"
+		keyPEM     = "leaf-key"
+		oldCertPEM = "old-leaf-certificate"
+		oldKeyPEM  = "old-leaf-key"
+	)
+
+	leafHash := func(cert, key string) string {
+		return fmt.Sprintf("%x", md5.Sum([]byte(cert+key)))
+	}
+
+	newCR := func(crVersion string, state apiv1.StatefulAppState, paused bool) *apiv1.PerconaServerMySQL {
+		return &apiv1.PerconaServerMySQL{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: apiv1.PerconaServerMySQLSpec{
+				CRVersion:     crVersion,
+				SSLSecretName: sslSecret,
+				Pause:         paused,
+				MySQL: apiv1.MySQLSpec{
+					ClusterType: apiv1.ClusterTypeGR,
+					PodSpec:     apiv1.PodSpec{Size: podCount},
+				},
+			},
+			Status: apiv1.PerconaServerMySQLStatus{State: state},
+		}
+	}
+
+	newSTS := func(cr *apiv1.PerconaServerMySQL, lastReloaded string) *appsv1.StatefulSet {
+		annotations := make(map[string]string)
+		if lastReloaded != "" {
+			annotations[naming.AnnotationLastReloadedTLS.String()] = lastReloaded
+		}
+
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        mysql.Name(cr),
+				Namespace:   cr.Namespace,
+				Annotations: annotations,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: mysql.MatchLabels(cr)},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: mysql.MatchLabels(cr)},
+				},
+			},
+		}
+	}
+
+	newTLSSecret := func(cert, key string) client.Object {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: sslSecret, Namespace: ns},
+			Data: map[string][]byte{
+				naming.TLSCAKey:   []byte(caPEM),
+				naming.TLSCertKey: []byte(cert),
+				naming.TLSKeyKey:  []byte(key),
+			},
+		}
+	}
+
+	newInternalSecret := func() client.Object {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "internal-" + crName, Namespace: ns},
+			Data:       map[string][]byte{string(apiv1.UserOperator): []byte(operatorPass)},
+		}
+	}
+
+	podName := func(idx int) string {
+		return fmt.Sprintf("%s-mysql-%d", crName, idx)
+	}
+
+	newPods := func(count int) []client.Object {
+		cr := newCR("", "", false)
+
+		objs := make([]client.Object, 0, count)
+		for i := range count {
+			objs = append(objs, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName(i),
+					Namespace: ns,
+					Labels:    mysql.MatchLabels(cr),
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			})
+		}
+		return objs
+	}
+
+	world := func(running int) []client.Object {
+		return append([]client.Object{newInternalSecret()}, newPods(running)...)
+	}
+
+	catCmd := []string{
+		"cat",
+		mysql.TLSMountPath + "/" + naming.TLSCertKey,
+		mysql.TLSMountPath + "/" + naming.TLSKeyKey,
+	}
+
+	reloadCmd := func(cr *apiv1.PerconaServerMySQL, pod string) []string {
+		return []string{
+			"mysql",
+			"--database", "performance_schema",
+			"-p" + operatorPass,
+			"-u", string(apiv1.UserOperator),
+			"-h", pod + "." + mysql.ServiceName(cr) + "." + cr.Namespace,
+			"-e", reloadStmt,
+		}
+	}
+
+	tests := map[string]struct {
+		crVersion    string // defaults to 1.3.0
+		state        apiv1.StatefulAppState
+		paused       bool
+		secret       client.Object   // the TLS secret; nil means it does not exist
+		lastReloaded string          // hash on the statefulset annotation; empty means absent
+		object       []client.Object // what the API holds besides CR, statefulset and TLS secret; nil means a healthy cluster
+
+		podCert      string // certificate the pods hold on disk; defaults to the one in the secret
+		podKey       string
+		expectReload bool // ALTER INSTANCE RELOAD TLS expected on every pod
+		expectedErr  error
+		expectedHash string // last reloaded annotation expected afterwards; empty means absent
+	}{
+		"version gate skips 1.2.0": {
+			crVersion:    "1.2.0",
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"new cluster records the hash without touching mysql": {
+			state:        apiv1.StateNew,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			expectedHash: leafHash(certPEM, keyPEM),
+		},
+		"cluster without a recorded hash records it": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			expectedHash: leafHash(certPEM, keyPEM),
+		},
+		"missing TLS secret is ignored": {
+			state:        apiv1.StateReady,
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"secret without a certificate is ignored": {
+			state: apiv1.StateReady,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: sslSecret, Namespace: ns},
+				Data:       map[string][]byte{naming.TLSCAKey: []byte(caPEM)},
+			},
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"unchanged certificate runs no statements": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(certPEM, keyPEM),
+			expectedHash: leafHash(certPEM, keyPEM),
+		},
+		"rotated certificate is reloaded on every pod": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectReload: true,
+			expectedHash: leafHash(certPEM, keyPEM),
+		},
+		"initializing cluster is reloaded": {
+			state:        apiv1.StateInitializing,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectReload: true,
+			expectedHash: leafHash(certPEM, keyPEM),
+		},
+		"paused cluster is deferred": {
+			state:        apiv1.StatePaused,
+			paused:       true,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			object:       world(0),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"reload is deferred until every pod is running": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			object:       world(podCount - 1),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		// kubelet refreshes the mounted secret on its own schedule, and reloading
+		// before it lands would leave the new certificate unused.
+		"reload is deferred until the certificate reaches the pods": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			podCert:      oldCertPEM,
+			podKey:       oldKeyPEM,
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"sql error is returned and the hash is not recorded": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			expectReload: true,
+			expectedErr:  errors.New("reload TLS on pod " + podName(0)),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+		"missing operator password is returned": {
+			state:        apiv1.StateReady,
+			secret:       newTLSSecret(certPEM, keyPEM),
+			lastReloaded: leafHash(oldCertPEM, oldKeyPEM),
+			object:       newPods(podCount), // everything but the internal secret
+			expectedErr:  errors.New("get operator password"),
+			expectedHash: leafHash(oldCertPEM, oldKeyPEM),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := newScheme(t)
+
+			crVersion := tt.crVersion
+			if crVersion == "" {
+				crVersion = "1.3.0"
+			}
+			cr := newCR(crVersion, tt.state, tt.paused)
+			sts := newSTS(cr, tt.lastReloaded)
+
+			objs := []client.Object{cr, sts.DeepCopy()}
+			if tt.secret != nil {
+				objs = append(objs, tt.secret)
+			}
+			if tt.object != nil {
+				objs = append(objs, tt.object...)
+			} else {
+				objs = append(objs, world(podCount)...)
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+			podCert, podKey := tt.podCert, tt.podKey
+			if podCert == "" {
+				podCert, podKey = certPEM, keyPEM
+			}
+
+			cliCmd := clientcmdmock.NewClient(t)
+
+			catPods := 0
+			switch {
+			case tt.podCert != "":
+				catPods = 1
+			case tt.expectReload || tt.expectedErr != nil:
+				catPods = podCount
+			}
+			for i := range catPods {
+				pod := podName(i)
+				cliCmd.On("Exec",
+					mock.Anything,
+					mock.MatchedBy(func(p *corev1.Pod) bool { return p.Name == pod }),
+					"mysql",
+					catCmd,
+					mock.Anything, // stdin
+					mock.Anything, // stdout
+					mock.Anything, // stderr
+					false,         // tty
+				).Return(nil).Once().Run(func(args mock.Arguments) {
+					_, _ = args.Get(5).(io.Writer).Write([]byte(podCert + podKey))
+				})
+			}
+
+			if tt.expectReload {
+				pods := podCount
+				if tt.expectedErr != nil {
+					pods = 1
+				}
+				for i := range pods {
+					pod := podName(i)
+					call := cliCmd.On("Exec",
+						mock.Anything,
+						mock.MatchedBy(func(p *corev1.Pod) bool { return p.Name == pod }),
+						"mysql",
+						reloadCmd(cr, pod),
+						mock.Anything,
+						mock.Anything,
+						mock.Anything,
+						false,
+					).Return(nil).Once()
+
+					if tt.expectedErr != nil {
+						call.Run(func(args mock.Arguments) {
+							_, _ = args.Get(6).(io.Writer).Write([]byte(stderrDenied))
+						})
+					}
+				}
+			}
+
+			r := &PerconaServerMySQLReconciler{Client: cl, Scheme: scheme, ClientCmd: cliCmd}
+
+			err := r.reconcileTLSReload(ctx, cr, sts)
+			if tt.expectedErr != nil {
+				require.ErrorContains(t, err, tt.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			updated := new(appsv1.StatefulSet)
+			require.NoError(t, cl.Get(ctx, types.NamespacedName{Name: mysql.Name(cr), Namespace: cr.Namespace}, updated))
+
+			hash, ok := updated.Annotations[naming.AnnotationLastReloadedTLS.String()]
+			if tt.expectedHash == "" {
+				assert.False(t, ok, "last reloaded TLS annotation must be absent")
+			} else {
+				assert.Equal(t, tt.expectedHash, hash, "last reloaded TLS annotation")
+			}
+		})
+	}
+}

--- a/pkg/db/admin.go
+++ b/pkg/db/admin.go
@@ -47,6 +47,13 @@ func (m *AdminManager) SetSuperReadOnly(ctx context.Context, readonly bool) erro
 	return nil
 }
 
+// ReloadTLS makes mysqld re-read its certificate files. It only affects
+// connections opened after it returns.
+func (m *AdminManager) ReloadTLS(ctx context.Context) error {
+	var errb, outb bytes.Buffer
+	return m.db.exec(ctx, "ALTER INSTANCE RELOAD TLS", &outb, &errb)
+}
+
 var (
 	variableNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 	loosePrefixRegex  = regexp.MustCompile(`^loose[-_]`)

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -190,6 +190,7 @@ func EnsureObjectWithHash(
 	preserveAnnotations := []string{
 		"deployment.kubernetes.io/revision",
 		string(naming.AnnotationLastAppliedConfig),
+		string(naming.AnnotationLastReloadedTLS),
 	}
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -537,17 +538,13 @@ func GetImageIDFromPod(pod *corev1.Pod, containerName string) (string, error) {
 	return pod.Status.ContainerStatuses[idx].ImageID, nil
 }
 
+// GetTLSHash returns the hash a pod template carries so that a change in the
+// TLS secret rolls it out. Orchestrator, HAProxy and Router read the
+// certificates once at startup, so any change to them means a restart.
 func GetTLSHash(ctx context.Context, cl client.Client, cr *apiv1.PerconaServerMySQL) (string, error) {
-	secret := new(corev1.Secret)
-	err := cl.Get(ctx, types.NamespacedName{
-		Name:      cr.Spec.SSLSecretName,
-		Namespace: cr.Namespace,
-	}, secret)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return "", nil
-		}
-		return "", errors.Wrap(err, "get secret")
+	secret, err := tlsSecret(ctx, cl, cr)
+	if err != nil || secret == nil {
+		return "", err
 	}
 
 	hash, err := ObjectHash(secret)
@@ -556,6 +553,44 @@ func GetTLSHash(ctx context.Context, cl client.Client, cr *apiv1.PerconaServerMy
 	}
 
 	return hash, nil
+}
+
+// GetMySQLTLSHash returns the same hash for the MySQL pod template, except that
+// starting with 1.3.0 it only covers the CA: a new leaf signed by the same CA
+// is reloaded into the running mysqld instead of restarting it.
+func GetMySQLTLSHash(ctx context.Context, cl client.Client, cr *apiv1.PerconaServerMySQL) (string, error) {
+	secret, err := tlsSecret(ctx, cl, cr)
+	if err != nil || secret == nil {
+		return "", err
+	}
+
+	// Without a CA there is nothing to tell a leaf rotation from a CA rotation.
+	if cr.CompareVersion("1.3.0") < 0 || len(secret.Data[naming.TLSCAKey]) == 0 {
+		hash, err := ObjectHash(secret)
+		if err != nil {
+			return "", errors.Wrap(err, "get secret hash")
+		}
+		return hash, nil
+	}
+
+	return fmt.Sprintf("%x", md5.Sum(secret.Data[naming.TLSCAKey])), nil
+}
+
+// tlsSecret returns nil without an error when the secret does not exist yet.
+func tlsSecret(ctx context.Context, cl client.Client, cr *apiv1.PerconaServerMySQL) (*corev1.Secret, error) {
+	secret := new(corev1.Secret)
+	err := cl.Get(ctx, types.NamespacedName{
+		Name:      cr.Spec.SSLSecretName,
+		Namespace: cr.Namespace,
+	}, secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "get secret")
+	}
+
+	return secret, nil
 }
 
 func setCRVersion(

--- a/pkg/k8s/utils_test.go
+++ b/pkg/k8s/utils_test.go
@@ -770,3 +770,95 @@ func TestEnsureObjectWithHash(t *testing.T) {
 		assert.Equal(t, []byte("new-value"), got.Data["key"])
 	})
 }
+
+func TestGetTLSHash(t *testing.T) {
+	const (
+		crName    = "cluster1"
+		ns        = "tls-ns"
+		sslSecret = "cluster1-ssl"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, apiv1.AddToScheme(scheme))
+
+	newCR := func(crVersion string) *apiv1.PerconaServerMySQL {
+		return &apiv1.PerconaServerMySQL{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: apiv1.PerconaServerMySQLSpec{
+				CRVersion:     crVersion,
+				SSLSecretName: sslSecret,
+			},
+		}
+	}
+
+	newSecret := func(ca, cert, key string) *corev1.Secret {
+		data := make(map[string][]byte)
+		if ca != "" {
+			data[naming.TLSCAKey] = []byte(ca)
+		}
+		data[naming.TLSCertKey] = []byte(cert)
+		data[naming.TLSKeyKey] = []byte(key)
+
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: sslSecret, Namespace: ns},
+			Data:       data,
+		}
+	}
+
+	hashes := func(t *testing.T, crVersion string, secret *corev1.Secret) (string, string) {
+		t.Helper()
+
+		objs := []client.Object{newCR(crVersion)}
+		if secret != nil {
+			objs = append(objs, secret)
+		}
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+		all, err := GetTLSHash(context.Background(), cl, newCR(crVersion))
+		require.NoError(t, err)
+		mysql, err := GetMySQLTLSHash(context.Background(), cl, newCR(crVersion))
+		require.NoError(t, err)
+
+		return all, mysql
+	}
+
+	t.Run("missing secret hashes to nothing", func(t *testing.T) {
+		all, mysql := hashes(t, "1.3.0", nil)
+
+		assert.Empty(t, all)
+		assert.Empty(t, mysql)
+	})
+
+	t.Run("a rotated leaf leaves the mysql hash alone", func(t *testing.T) {
+		allBefore, mysqlBefore := hashes(t, "1.3.0", newSecret("ca", "cert", "key"))
+		allAfter, mysqlAfter := hashes(t, "1.3.0", newSecret("ca", "new-cert", "new-key"))
+
+		assert.NotEqual(t, allBefore, allAfter, "proxies read their certificates once and must be restarted")
+		assert.Equal(t, mysqlBefore, mysqlAfter, "mysqld reloads the leaf and must not be restarted")
+	})
+
+	t.Run("a rotated CA changes every hash", func(t *testing.T) {
+		allBefore, mysqlBefore := hashes(t, "1.3.0", newSecret("ca", "cert", "key"))
+		allAfter, mysqlAfter := hashes(t, "1.3.0", newSecret("new-ca", "cert", "key"))
+
+		assert.NotEqual(t, allBefore, allAfter)
+		assert.NotEqual(t, mysqlBefore, mysqlAfter)
+	})
+
+	t.Run("a rotated leaf without a CA restarts mysql too", func(t *testing.T) {
+		allBefore, mysqlBefore := hashes(t, "1.3.0", newSecret("", "cert", "key"))
+		allAfter, mysqlAfter := hashes(t, "1.3.0", newSecret("", "new-cert", "new-key"))
+
+		assert.NotEqual(t, allBefore, allAfter)
+		assert.NotEqual(t, mysqlBefore, mysqlAfter)
+	})
+
+	t.Run("version gate skips 1.2.0", func(t *testing.T) {
+		allBefore, mysqlBefore := hashes(t, "1.2.0", newSecret("ca", "cert", "key"))
+		allAfter, mysqlAfter := hashes(t, "1.2.0", newSecret("ca", "new-cert", "new-key"))
+
+		assert.NotEqual(t, allBefore, allAfter)
+		assert.NotEqual(t, mysqlBefore, mysqlAfter)
+	})
+}

--- a/pkg/mysql/component.go
+++ b/pkg/mysql/component.go
@@ -69,7 +69,7 @@ func (c *Component) Object(ctx context.Context, cl client.Client) (client.Object
 		configHash = ""
 	}
 
-	tlsHash, err := k8s.GetTLSHash(ctx, cl, cr)
+	tlsHash, err := k8s.GetMySQLTLSHash(ctx, cl, cr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get tls hash")
 	}

--- a/pkg/mysql/mysql.go
+++ b/pkg/mysql/mysql.go
@@ -30,7 +30,7 @@ const (
 	mysqlshVolumeName     = "mysqlsh"
 	mysqlshMountPath      = "/.mysqlsh"
 	tlsVolumeName         = "tls"
-	tlsMountPath          = "/etc/mysql/mysql-tls-secret"
+	TLSMountPath          = "/etc/mysql/mysql-tls-secret"
 	BackupLogDir          = "/var/log/xtrabackup"
 	vaultSecretVolumeName = "vault-keyring-secret"
 	vaultSecretMountPath  = "/etc/mysql/vault-keyring-secret"
@@ -646,7 +646,7 @@ func mysqldVolumeMounts(cr *apiv1.PerconaServerMySQL) []corev1.VolumeMount {
 		},
 		{
 			Name:      tlsVolumeName,
-			MountPath: tlsMountPath,
+			MountPath: TLSMountPath,
 		},
 		{
 			Name:      configVolumeName,

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -49,6 +49,13 @@ const (
 	AnnotationClusterSetRecoveryNeeded AnnotationKey = perconaPrefix + "clusterset-recovery-needed"
 	AnnotationClusterSetRejoinCluster  AnnotationKey = perconaPrefix + "clusterset-rejoin-cluster"
 	AnnotationLastAppliedConfig        AnnotationKey = perconaPrefix + "last-applied-config"
+	AnnotationLastReloadedTLS          AnnotationKey = perconaPrefix + "last-reloaded-tls"
+)
+
+const (
+	TLSCAKey   = "ca.crt"
+	TLSCertKey = "tls.crt"
+	TLSKeyKey  = "tls.key"
 )
 
 const ClusterSetRecoveryFile = "/var/lib/mysql/clusterset-recovery"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

Ticket: K8SPS-471

Rotating the TLS leaf certificate previously triggered a full rolling restart of the MySQL StatefulSet. Now, when a new leaf is issued by the same CA, the operator reloads the certificate into the running mysqld instances instead of restarting them. CA rotation still restarts pods, and Orchestrator, HAProxy and Router keep their existing restart behaviour since they only read certificates at startup.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
