### PR TITLE
K8SPS-552 grant delete on RBAC objects to fix cluster creation on OpenShift

### DIFF
--- a/config/rbac/cluster/role.yaml
+++ b/config/rbac/cluster/role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -28,17 +29,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -114,6 +104,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -149,6 +140,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -28,17 +29,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -114,6 +104,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -149,6 +140,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1395,9 +1395,6 @@ spec:
                       type: string
                     primary:
                       type: string
-                    replicationLagSeconds:
-                      format: int64
-                      type: integer
                   required:
                   - clusterRole
                   - globalStatus
@@ -14773,6 +14770,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -14791,17 +14789,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -14877,6 +14864,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -14912,6 +14900,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1395,6 +1395,9 @@ spec:
                       type: string
                     primary:
                       type: string
+                    replicationLagSeconds:
+                      format: int64
+                      type: integer
                   required:
                   - clusterRole
                   - globalStatus

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -1395,9 +1395,6 @@ spec:
                       type: string
                     primary:
                       type: string
-                    replicationLagSeconds:
-                      format: int64
-                      type: integer
                   required:
                   - clusterRole
                   - globalStatus
@@ -14773,6 +14770,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -14791,17 +14789,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -14877,6 +14864,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -14912,6 +14900,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -1395,6 +1395,9 @@ spec:
                       type: string
                     primary:
                       type: string
+                    replicationLagSeconds:
+                      format: int64
+                      type: integer
                   required:
                   - clusterRole
                   - globalStatus

--- a/deploy/cw-rbac.yaml
+++ b/deploy/cw-rbac.yaml
@@ -51,6 +51,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -69,17 +70,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -155,6 +145,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -190,6 +181,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -51,6 +51,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -69,17 +70,6 @@ rules:
   - create
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
   - get
   - list
   - patch
@@ -155,6 +145,7 @@ rules:
   - poddisruptionbudgets/finalizers
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -190,6 +181,7 @@ rules:
   - roles
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/pkg/controller/ps/controller.go
+++ b/pkg/controller/ps/controller.go
@@ -78,12 +78,12 @@ type PerconaServerMySQLReconciler struct {
 //+kubebuilder:rbac:groups="",resources=configmaps;services;secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=pods;pods/exec,verbs=get;list;watch;create;update;patch;delete;deletecollection
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch;create;patch
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;patch
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;patch;delete
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets;deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets;poddisruptionbudgets/finalizers,verbs=create;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets;poddisruptionbudgets/finalizers,verbs=create;get;list;patch;update;watch;delete
 //+kubebuilder:rbac:groups=certmanager.k8s.io;cert-manager.io,resources=issuers;certificates,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=ps.percona.com,resources=perconaservermysqls;perconaservermysqls/status;perconaservermysqls/finalizers,verbs=get;list;watch;create;update;patch;delete
 

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -369,8 +369,8 @@ func (r *PerconaServerMySQLClusterSetReconciler) bootstrapClusterSet(ctx context
 }
 
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 func (r *PerconaServerMySQLClusterSetReconciler) reconcileReplicas(ctx context.Context, pcs *apiv1.PerconaServerMySQLClusterSet) error {
 	// Add replicas to the clusterset if not added already
@@ -731,7 +731,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileForcedFailover(
 }
 
 // Returns the names of clusters that are in a but not in b.
-func clusterSetMemberDiff(a, b apiv1.ClusterSetClusterStatuses) []string {
+func clusterSetMemberDiff(a, b apiv1.ClusterSetStatus) []string {
 	diff := []string{}
 	for name := range a {
 		if _, ok := b[name]; !ok {
@@ -781,7 +781,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 		meta.SetStatusCondition(&status.Conditions, readyCond)
 
 		// Emit an event for each newly added member
-		newlyAdded := clusterSetMemberDiff(observedStatus.Clusters.IntoAPI(), status.Clusters)
+		newlyAdded := clusterSetMemberDiff(observedStatus.Clusters, status.Clusters)
 		for _, name := range newlyAdded {
 			events = append(events, func() {
 				r.Recorder.Eventf(pcs, nil, corev1.EventTypeNormal, apiv1.EventTypeClusterSetMemberAdded,
@@ -790,7 +790,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 		}
 
 		// Emit an event for each newly removed member
-		newlyRemoved := clusterSetMemberDiff(status.Clusters, observedStatus.Clusters.IntoAPI())
+		newlyRemoved := clusterSetMemberDiff(status.Clusters, observedStatus.Clusters)
 		for _, name := range newlyRemoved {
 			events = append(events, func() {
 				r.Recorder.Eventf(pcs, nil, corev1.EventTypeNormal, apiv1.EventTypeClusterSetMemberRemoved, apiv1.EventTypeClusterSetMemberRemoved, "Cluster %s removed from ClusterSet", name)
@@ -806,7 +806,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 			})
 		}
 
-		status.Clusters = observedStatus.Clusters.IntoAPI()
+		status.Clusters = observedStatus.Clusters
 		status.PrimaryCluster = observedStatus.PrimaryCluster
 		status.PrimaryClusterEndpoint = observedStatus.GlobalPrimaryInstance
 		return nil
@@ -862,7 +862,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) dissolveClusterSet(
 	clusters := observedStatus.Clusters
 
 	if err := pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-		status.Clusters = observedStatus.Clusters.IntoAPI()
+		status.Clusters = observedStatus.Clusters
 		status.Conditions = []metav1.Condition{}
 		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 			Type:    apiv1.ConditionClusterSetDissolving,

--- a/pkg/controller/psclusterset/controller.go
+++ b/pkg/controller/psclusterset/controller.go
@@ -731,7 +731,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileForcedFailover(
 }
 
 // Returns the names of clusters that are in a but not in b.
-func clusterSetMemberDiff(a, b apiv1.ClusterSetStatus) []string {
+func clusterSetMemberDiff(a, b apiv1.ClusterSetClusterStatuses) []string {
 	diff := []string{}
 	for name := range a {
 		if _, ok := b[name]; !ok {
@@ -781,7 +781,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 		meta.SetStatusCondition(&status.Conditions, readyCond)
 
 		// Emit an event for each newly added member
-		newlyAdded := clusterSetMemberDiff(observedStatus.Clusters, status.Clusters)
+		newlyAdded := clusterSetMemberDiff(observedStatus.Clusters.IntoAPI(), status.Clusters)
 		for _, name := range newlyAdded {
 			events = append(events, func() {
 				r.Recorder.Eventf(pcs, nil, corev1.EventTypeNormal, apiv1.EventTypeClusterSetMemberAdded,
@@ -790,7 +790,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 		}
 
 		// Emit an event for each newly removed member
-		newlyRemoved := clusterSetMemberDiff(status.Clusters, observedStatus.Clusters)
+		newlyRemoved := clusterSetMemberDiff(status.Clusters, observedStatus.Clusters.IntoAPI())
 		for _, name := range newlyRemoved {
 			events = append(events, func() {
 				r.Recorder.Eventf(pcs, nil, corev1.EventTypeNormal, apiv1.EventTypeClusterSetMemberRemoved, apiv1.EventTypeClusterSetMemberRemoved, "Cluster %s removed from ClusterSet", name)
@@ -806,7 +806,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) reconcileStatus(ctx context.Con
 			})
 		}
 
-		status.Clusters = observedStatus.Clusters
+		status.Clusters = observedStatus.Clusters.IntoAPI()
 		status.PrimaryCluster = observedStatus.PrimaryCluster
 		status.PrimaryClusterEndpoint = observedStatus.GlobalPrimaryInstance
 		return nil
@@ -862,7 +862,7 @@ func (r *PerconaServerMySQLClusterSetReconciler) dissolveClusterSet(
 	clusters := observedStatus.Clusters
 
 	if err := pcs.UpdateStatus(ctx, r.Client, func(status *apiv1.PerconaServerMySQLClusterSetStatus) error {
-		status.Clusters = observedStatus.Clusters
+		status.Clusters = observedStatus.Clusters.IntoAPI()
 		status.Conditions = []metav1.Condition{}
 		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 			Type:    apiv1.ConditionClusterSetDissolving,


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
```
2025-09-21T15:40:12.816Z        ERROR   Reconciler error        {"controller": "ps-controller", "controllerGroup": "ps.percona.com", "controllerKind": "PerconaServerMySQL", "PerconaServerMySQL": {"name":"ps-cluster6","namespace":"test1"}, "namespace": "test1", "name": "ps-cluster6", "reconcileID": "e3dd64d6-fd76-41bf-ac7e-f06e1e560cec", "error": "reconcile: orchestrator: create role: patch test1/percona-server-mysql-operator-orchestrator: roles.rbac.authorization.k8s.io \"percona-server-mysql-operator-orchestrator\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>", "errorVerbose": "roles.rbac.authorization.k8s.io \"percona-server-mysql-operator-orchestrator\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>\npatch test1/percona-server-mysql-operator-orchestrator\ngithub.com/percona/percona-server-mysql-operator/pkg/k8s.EnsureObjectWithHash\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/k8s/utils.go:258\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).reconcileOrchestrator\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:722\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:455\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:139\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\ncreate role\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).reconcileOrchestrator\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:723\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:455\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:139\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\norchestrator\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).doReconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:456\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:139\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\nreconcile\ngithub.com/percona/percona-server-mysql-operator/pkg/controller/ps.(*PerconaServerMySQLReconciler).Reconcile\n\t/go/src/github.com/percona/percona-server-mysql-operator/pkg/controller/ps/controller.go:140\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:474
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:421
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.1/pkg/internal/controller/controller.go:296 
```

**Cause:**
```
oc -n openshift-kube-apiserver get cm config -o jsonpath='{.data.config\.yaml}' | python3 -c "import json,sys; print(*json.load(sys.stdin)['apiServerArguments'].get('enable-admission-plugins'), sep='\n')" | grep -i ref
OwnerReferencesPermissionEnforcement
```
This admission controller protects the access to the metadata.ownerReferences of an object so that only users with delete permission to the object can change it. The admission is on for openshift by default. 

**Solution:**
Add delete permissions. 


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PS version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
